### PR TITLE
Rewrite for the customResource system to handle all types of data

### DIFF
--- a/content/forgero-compat/src/main/resources/data/forgero/packs/ae2/material/fluix.json
+++ b/content/forgero-compat/src/main/resources/data/forgero/packs/ae2/material/fluix.json
@@ -63,5 +63,23 @@
         "value": 0
       }
     ]
+  },
+  "custom_data": {
+    "enchantment": [
+      {
+        "targets": [
+          "type:PICKAXE_HEAD"
+        ],
+        "id": "minecraft:fortune",
+        "level": 1
+      },
+      {
+        "targets": [
+          "type:SWORD_BLADE"
+        ],
+        "id": "minecraft:looting",
+        "level": 1
+      }
+    ]
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/axe-additions/schematic/battle_axe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/axe-additions/schematic/battle_axe_head.json
@@ -94,7 +94,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "4",
+    "ingredient_count": {
+      "value": 4,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:heavy_axe"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/axe-additions/schematic/tree_chopper_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/axe-additions/schematic/tree_chopper_head.json
@@ -103,6 +103,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/axe-additions/schematic/tree_feller_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/axe-additions/schematic/tree_feller_head.json
@@ -104,6 +104,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/forgero-extended/schematic/mastercrafted_handle.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/forgero-extended/schematic/mastercrafted_handle.json
@@ -100,6 +100,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/forgero-extended/schematic/reinforced_handle.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/forgero-extended/schematic/reinforced_handle.json
@@ -94,6 +94,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/forgero-extended/schematic/spiked_binding.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/forgero-extended/schematic/spiked_binding.json
@@ -95,6 +95,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/hoe-additions/schematic/mastercrafted_hoe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/hoe-additions/schematic/mastercrafted_hoe_head.json
@@ -104,6 +104,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/hoe-additions/schematic/reaper_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/hoe-additions/schematic/reaper_head.json
@@ -103,7 +103,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2",
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:scythe"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/hoe-additions/schematic/refined_hoe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/hoe-additions/schematic/refined_hoe_head.json
@@ -104,6 +104,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/lightweight_pickaxe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/lightweight_pickaxe_head.json
@@ -102,6 +102,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/mastercrafted_pickaxe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/mastercrafted_pickaxe_head.json
@@ -102,6 +102,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/ore_miner_pickaxe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/ore_miner_pickaxe_head.json
@@ -111,6 +111,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/path_mining_pickaxe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/path_mining_pickaxe_head.json
@@ -111,6 +111,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/refined_pickaxe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/pickaxe-additions/schematic/refined_pickaxe_head.json
@@ -102,6 +102,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/shovel-additions/schematic/grave_digger_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/shovel-additions/schematic/grave_digger_head.json
@@ -105,6 +105,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/shovel-additions/schematic/pathdigger_shovel_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/shovel-additions/schematic/pathdigger_shovel_head.json
@@ -112,6 +112,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/agile_sword_guard.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/agile_sword_guard.json
@@ -95,6 +95,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "1"
+    "ingredient_count": {
+      "value": 1,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/broadsword_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/broadsword_blade.json
@@ -89,7 +89,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "4",
+    "ingredient_count": {
+      "value": 4,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:claymore"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/duelling_sword_guard.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/duelling_sword_guard.json
@@ -87,6 +87,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "1"
+    "ingredient_count": {
+      "value": 1,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/katana_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/katana_blade.json
@@ -89,7 +89,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2",
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:katana"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/kimiri_sword_guard.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/kimiri_sword_guard.json
@@ -95,6 +95,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "1"
+    "ingredient_count": {
+      "value": 1,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/knife_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/knife_blade.json
@@ -89,7 +89,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "1",
+    "ingredient_count": {
+      "value": 1,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:dagger"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/mastercrafted_sword_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/mastercrafted_sword_blade.json
@@ -114,6 +114,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/rapier_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/rapier_blade.json
@@ -80,7 +80,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2",
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:rapier"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/refined_sword_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/refined_sword_blade.json
@@ -110,6 +110,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/saber_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/saber_blade.json
@@ -98,7 +98,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3",
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:cutlass"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/scimitar_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/scimitar_blade.json
@@ -89,7 +89,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": 2,
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:cutlass"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/scimitar_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/scimitar_blade.json
@@ -89,7 +89,7 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2",
+    "ingredient_count": 2,
     "better_compat_attribute_container": "bettercombat:cutlass"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/serrated_sword_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/serrated_sword_blade.json
@@ -103,7 +103,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3",
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:claymore"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/shortsword_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/shortsword_blade.json
@@ -89,7 +89,10 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2",
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    },
     "better_compat_attribute_container": "bettercombat:dagger"
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/slanted_sword_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/slanted_sword_blade.json
@@ -107,6 +107,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/tsuba_sword_guard.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/tsuba_sword_guard.json
@@ -95,6 +95,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "1"
+    "ingredient_count": {
+      "value": 1,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/axe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/axe_head.json
@@ -88,6 +88,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/binding.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/binding.json
@@ -98,6 +98,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/handle.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/handle.json
@@ -82,6 +82,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/hoe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/hoe_head.json
@@ -88,6 +88,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/pickaxe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/pickaxe_head.json
@@ -81,6 +81,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "3"
+    "ingredient_count": {
+      "value": 3,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/pummel.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/pummel.json
@@ -33,9 +33,6 @@
       }
     ],
     "slots": [
-    ],
-    "models": [
-      {}
     ]
   },
   "properties": {
@@ -70,6 +67,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "1"
+    "ingredient_count": {
+      "value": 1,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/shovel_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/shovel_head.json
@@ -88,6 +88,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "1"
+    "ingredient_count": {
+      "value": 1,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade.json
@@ -90,6 +90,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_guard.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_guard.json
@@ -95,6 +95,9 @@
     ]
   },
   "custom_data": {
-    "ingredient_count": "2"
+    "ingredient_count": {
+      "value": 2,
+      "context": "LOCAL"
+    }
   }
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/BetterCombatWeaponRegistryMixin.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/BetterCombatWeaponRegistryMixin.java
@@ -1,22 +1,22 @@
 package com.sigmundgranaas.forgero.fabric.mixins;
 
+import java.util.Map;
+import java.util.Optional;
+
 import com.sigmundgranaas.forgero.core.state.SchematicBased;
 import com.sigmundgranaas.forgero.core.state.composite.ConstructedTool;
 import com.sigmundgranaas.forgero.minecraft.common.conversion.StateConverter;
 import net.bettercombat.api.AttributesContainer;
 import net.bettercombat.api.WeaponAttributes;
 import net.bettercombat.logic.WeaponRegistry;
-
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.Identifier;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Map;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
 
 
 @Mixin(WeaponRegistry.class)
@@ -31,9 +31,9 @@ public abstract class BetterCombatWeaponRegistryMixin {
 		if (state.isPresent() && state.get() instanceof ConstructedTool tool) {
 			var head = tool.getHead();
 			if (head instanceof SchematicBased based) {
-				var better_combat_attributes_id = based.schematic().getCustomValue(BETTER_COMPAT_ATTRIBUTE_IDENTIFIER);
+				Optional<String> better_combat_attributes_id = based.schematic().customData().getString(BETTER_COMPAT_ATTRIBUTE_IDENTIFIER);
 				if (better_combat_attributes_id.isPresent()) {
-					var id = new Identifier(better_combat_attributes_id.get().presentableValue());
+					var id = new Identifier(better_combat_attributes_id.get());
 					if (containers.containsKey(id)) {
 						var container = containers.get(id);
 						cir.setReturnValue(WeaponRegistry.resolveAttributes(new Identifier(tool.identifier()), container));

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/customdata/EnchantmentVisitor.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/customdata/EnchantmentVisitor.java
@@ -1,17 +1,27 @@
 package com.sigmundgranaas.forgero.minecraft.common.customdata;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import com.sigmundgranaas.forgero.core.customdata.ClassBasedVisitor;
 import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.customdata.DataVisitor;
+import com.sigmundgranaas.forgero.core.property.Target;
+
+import com.sigmundgranaas.forgero.core.property.TargetTypes;
+import com.sigmundgranaas.forgero.core.property.attribute.TypeTarget;
+import com.sigmundgranaas.forgero.core.resource.data.PropertyPojo;
+import com.sigmundgranaas.forgero.minecraft.common.conversion.StateConverter;
 import com.sigmundgranaas.forgero.minecraft.common.utils.RegistryUtils;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.registry.Registry;
+
+import javax.annotation.Nullable;
 
 /**
  * A {@link DataVisitor} for {@link EnchantmentData}.
@@ -54,6 +64,8 @@ public class EnchantmentVisitor extends ClassBasedVisitor<EnchantmentVisitor.Enc
 	public static class EnchantmentData {
 		private String id;
 		private int level;
+		@Nullable
+		private PropertyPojo.Condition condition;
 
 		/**
 		 * Embeds the enchantment into the {@link ItemStack} using native methods.
@@ -64,7 +76,17 @@ public class EnchantmentVisitor extends ClassBasedVisitor<EnchantmentVisitor.Enc
 			RegistryUtils.safeId(id())
 					.flatMap(id -> RegistryUtils.safeRegistryLookup(Registry.ENCHANTMENT, id))
 					.filter(enchant -> enchant.isAcceptableItem(stack))
+					.filter(enchant -> isConditionMet(stack))
 					.ifPresent(enchant -> stack.addEnchantment(enchant, level()));
+		}
+
+		public boolean isConditionMet(ItemStack stack) {
+			if(condition == null) {
+				return true;
+			}
+			Target target =	 new TypeTarget(Set.of(StateConverter.of(stack).orElseThrow().type().toString()));
+
+			return target.isApplicable(new HashSet<>(condition.tag), TargetTypes.TYPE);
 		}
 	}
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/customdata/EnchantmentVisitor.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/customdata/EnchantmentVisitor.java
@@ -1,0 +1,70 @@
+package com.sigmundgranaas.forgero.minecraft.common.customdata;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.sigmundgranaas.forgero.core.customdata.ClassBasedVisitor;
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
+import com.sigmundgranaas.forgero.core.customdata.DataVisitor;
+import com.sigmundgranaas.forgero.minecraft.common.utils.RegistryUtils;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.registry.Registry;
+
+/**
+ * A {@link DataVisitor} for {@link EnchantmentData}.
+ * <p>
+ * This visitor is used to extract {@link EnchantmentData} from a {@link DataContainer}.
+ * The enchantments are applied to the {@link ItemStack} using {@link EnchantmentData#embed(ItemStack)}.
+ */
+public class EnchantmentVisitor extends ClassBasedVisitor<EnchantmentVisitor.EnchantmentData> {
+	public static final String KEY = "enchantment";
+
+	private EnchantmentVisitor() {
+		super(EnchantmentData.class, KEY);
+	}
+
+	/**
+	 * Will extract the first {@link EnchantmentData} from the {@link DataContainer}.
+	 *
+	 * @param dataContainer any container can contain enchantments
+	 * @return the first enchantment, if present
+	 */
+	public static Optional<EnchantmentData> of(DataContainer dataContainer) {
+		return dataContainer.accept(new EnchantmentVisitor());
+	}
+
+	/**
+	 * Will extract all {@link EnchantmentData} from the {@link DataContainer}.
+	 *
+	 * @param dataContainer any container can contain enchantments
+	 * @return all enchantments, if present
+	 */
+	public static List<EnchantmentData> ofAll(DataContainer dataContainer) {
+		return new EnchantmentVisitor().visitMultiple(dataContainer);
+	}
+
+	/**
+	 * A data class for storing enchantment data.
+	 */
+	@Data
+	@Accessors(fluent = true)
+	public static class EnchantmentData {
+		private String id;
+		private int level;
+
+		/**
+		 * Embeds the enchantment into the {@link ItemStack} using native methods.
+		 *
+		 * @param stack the stack to embed the enchantment into
+		 */
+		public void embed(ItemStack stack) {
+			RegistryUtils.safeId(id())
+					.flatMap(id -> RegistryUtils.safeRegistryLookup(Registry.ENCHANTMENT, id))
+					.filter(enchant -> enchant.isAcceptableItem(stack))
+					.ifPresent(enchant -> stack.addEnchantment(enchant, level()));
+		}
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/customdata/EnchantmentVisitor.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/customdata/EnchantmentVisitor.java
@@ -1,27 +1,17 @@
 package com.sigmundgranaas.forgero.minecraft.common.customdata;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import com.sigmundgranaas.forgero.core.customdata.ClassBasedVisitor;
 import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.customdata.DataVisitor;
-import com.sigmundgranaas.forgero.core.property.Target;
-
-import com.sigmundgranaas.forgero.core.property.TargetTypes;
-import com.sigmundgranaas.forgero.core.property.attribute.TypeTarget;
-import com.sigmundgranaas.forgero.core.resource.data.PropertyPojo;
-import com.sigmundgranaas.forgero.minecraft.common.conversion.StateConverter;
 import com.sigmundgranaas.forgero.minecraft.common.utils.RegistryUtils;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.registry.Registry;
-
-import javax.annotation.Nullable;
 
 /**
  * A {@link DataVisitor} for {@link EnchantmentData}.
@@ -64,8 +54,6 @@ public class EnchantmentVisitor extends ClassBasedVisitor<EnchantmentVisitor.Enc
 	public static class EnchantmentData {
 		private String id;
 		private int level;
-		@Nullable
-		private PropertyPojo.Condition condition;
 
 		/**
 		 * Embeds the enchantment into the {@link ItemStack} using native methods.
@@ -76,17 +64,7 @@ public class EnchantmentVisitor extends ClassBasedVisitor<EnchantmentVisitor.Enc
 			RegistryUtils.safeId(id())
 					.flatMap(id -> RegistryUtils.safeRegistryLookup(Registry.ENCHANTMENT, id))
 					.filter(enchant -> enchant.isAcceptableItem(stack))
-					.filter(enchant -> isConditionMet(stack))
 					.ifPresent(enchant -> stack.addEnchantment(enchant, level()));
-		}
-
-		public boolean isConditionMet(ItemStack stack) {
-			if(condition == null) {
-				return true;
-			}
-			Target target =	 new TypeTarget(Set.of(StateConverter.of(stack).orElseThrow().type().toString()));
-
-			return target.isApplicable(new HashSet<>(condition.tag), TargetTypes.TYPE);
 		}
 	}
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/DefaultStateItem.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/DefaultStateItem.java
@@ -1,5 +1,8 @@
 package com.sigmundgranaas.forgero.minecraft.common.item;
 
+import java.util.List;
+
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.PropertyContainer;
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.state.StateProvider;
@@ -14,8 +17,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import net.minecraft.world.World;
-
-import java.util.List;
 
 public class DefaultStateItem extends Item implements StateItem, State {
 	private final StateProvider DEFAULT;
@@ -79,5 +80,10 @@ public class DefaultStateItem extends Item implements StateItem, State {
 	@Override
 	public boolean isEquippable() {
 		return false;
+	}
+
+	@Override
+	public DataContainer customData() {
+		return defaultState().customData();
 	}
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/GemItem.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/GemItem.java
@@ -1,5 +1,8 @@
 package com.sigmundgranaas.forgero.minecraft.common.item;
 
+import java.util.List;
+
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.PropertyContainer;
 import com.sigmundgranaas.forgero.core.state.LeveledState;
 import com.sigmundgranaas.forgero.core.state.State;
@@ -15,8 +18,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import net.minecraft.world.World;
-
-import java.util.List;
 
 public class GemItem extends Item implements StateItem, State {
 	private final State DEFAULT;
@@ -87,5 +88,10 @@ public class GemItem extends Item implements StateItem, State {
 	@Override
 	public boolean isEquippable() {
 		return false;
+	}
+
+	@Override
+	public DataContainer customData() {
+		return defaultState().customData();
 	}
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/StateItem.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/StateItem.java
@@ -1,5 +1,6 @@
 package com.sigmundgranaas.forgero.minecraft.common.item;
 
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.PropertyContainer;
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.type.Type;
@@ -45,5 +46,10 @@ public interface StateItem extends DynamicAttributeItem, State {
 
 	default boolean test(Matchable match, Context context) {
 		return defaultState().test(match, context);
+	}
+
+	@Override
+	default DataContainer customData() {
+		return defaultState().customData();
 	}
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/loot/StateFilter.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/loot/StateFilter.java
@@ -1,5 +1,10 @@
 package com.sigmundgranaas.forgero.minecraft.common.loot;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
 import com.google.common.collect.ImmutableList;
 import com.sigmundgranaas.forgero.core.ForgeroStateRegistry;
 import com.sigmundgranaas.forgero.core.property.AttributeType;
@@ -11,11 +16,6 @@ import lombok.Data;
 import net.minecraft.item.Item;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
 
 @Data
 @Builder(toBuilder = true)
@@ -68,23 +68,15 @@ public class StateFilter {
 		if (exclusion.stream().anyMatch(exclusion -> stringMatch(exclusion, state))) {
 			return false;
 		}
-
-		if (include.size() > 0 && include.stream().noneMatch(include -> stringMatch(include, state))) {
-			return false;
-		}
-
-		return true;
+		
+		return include.size() == 0 || include.stream().anyMatch(include -> stringMatch(include, state));
 	}
 
 	private boolean stringMatch(String match, State state) {
 		if (state.identifier().contains(match)) {
 			return true;
 		}
-		if (state.type().typeName().contains(match)) {
-			return true;
-		}
-
-		return false;
+		return state.type().typeName().contains(match);
 	}
 
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/tooltip/writer/SchematicWriter.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/tooltip/writer/SchematicWriter.java
@@ -1,5 +1,12 @@
 package com.sigmundgranaas.forgero.minecraft.common.tooltip.writer;
 
+import static com.sigmundgranaas.forgero.core.customdata.CommonTags.INGREDIENT_COUNT;
+import static com.sigmundgranaas.forgero.core.customdata.ContainerVisitor.VISITOR;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import com.sigmundgranaas.forgero.core.ForgeroStateRegistry;
 import com.sigmundgranaas.forgero.core.state.SchematicBased;
 import com.sigmundgranaas.forgero.core.state.State;
@@ -12,9 +19,6 @@ import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
-import java.util.List;
-import java.util.function.Supplier;
-
 public class SchematicWriter extends StateWriter {
 	public SchematicWriter(State state) {
 		super(state);
@@ -22,9 +26,9 @@ public class SchematicWriter extends StateWriter {
 
 	@Override
 	public void write(List<Text> tooltip, TooltipContext context) {
-		var materials = state.getCustomValue("ingredient_count");
+		Optional<Integer> materials = state.accept(VISITOR).flatMap(container -> container.getInteger(INGREDIENT_COUNT));
 		if (materials.isPresent()) {
-			MutableText materialText = Text.translatable("tooltip.forgero.material_count", "").formatted(Formatting.GRAY).append(Text.literal(materials.get().presentableValue()).formatted(Formatting.WHITE));
+			MutableText materialText = Text.translatable("tooltip.forgero.material_count").formatted(Formatting.GRAY).append(Text.literal(materials.get().toString()).formatted(Formatting.WHITE));
 			tooltip.add(materialText);
 		}
 

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/utils/RegistryUtils.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/utils/RegistryUtils.java
@@ -1,0 +1,24 @@
+package com.sigmundgranaas.forgero.minecraft.common.utils;
+
+import java.util.Optional;
+
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public class RegistryUtils {
+	public static Optional<Identifier> safeId(String id) {
+		try {
+			return Optional.of(new Identifier(id));
+		} catch (Exception e) {
+			return Optional.empty();
+		}
+	}
+
+	public static <T> Optional<T> safeRegistryLookup(Registry<T> registry, Identifier id) {
+		try {
+			return Optional.ofNullable(registry.get(id));
+		} catch (Exception e) {
+			return Optional.empty();
+		}
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/utils/RegistryUtils.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/utils/RegistryUtils.java
@@ -5,7 +5,16 @@ import java.util.Optional;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
+/**
+ * A utility class for working with registries. Will try to provide safe handling of registry lookups.
+ */
 public class RegistryUtils {
+	/**
+	 * Will try to safely create an {@link Identifier} from the given string.
+	 *
+	 * @param id the string to parse
+	 * @return the identifier, if the string is valid
+	 */
 	public static Optional<Identifier> safeId(String id) {
 		try {
 			return Optional.of(new Identifier(id));
@@ -14,6 +23,14 @@ public class RegistryUtils {
 		}
 	}
 
+	/**
+	 * Will try to safely look up an object in the given registry.
+	 *
+	 * @param registry the registry to lookup in
+	 * @param id       the id to lookup
+	 * @param <T>      the type of object to lookup
+	 * @return the object, if present
+	 */
 	public static <T> Optional<T> safeRegistryLookup(Registry<T> registry, Identifier id) {
 		try {
 			return Optional.ofNullable(registry.get(id));

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ClassBasedVisitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ClassBasedVisitor.java
@@ -3,7 +3,6 @@ package com.sigmundgranaas.forgero.core.customdata;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * A {@link DataVisitor} that visits a {@link DataContainer} and returns the value of the key
@@ -44,14 +43,7 @@ public class ClassBasedVisitor<T> implements DataVisitor<T> {
 	@Override
 	public List<T> visitMultiple(DataContainer dataContainer) {
 		if (dataContainer instanceof CustomJsonDataContainer customJsonDataContainer) {
-			List<T> results = customJsonDataContainer.getObject(key(), List.class)
-					.map(list -> (List<?>) list)
-					.orElse(Collections.emptyList())
-					.stream()
-					.filter(type::isInstance)
-					.map(type::cast)
-					.collect(Collectors.toList());
-
+			List<T> results = customJsonDataContainer.getObjectList(key(), type);
 			if (results.isEmpty()) {
 				visit(dataContainer).ifPresent(results::add);
 			}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ClassBasedVisitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ClassBasedVisitor.java
@@ -1,8 +1,17 @@
 package com.sigmundgranaas.forgero.core.customdata;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
-public class ClassBasedVisitor<T> implements DataVisitor<T>{
+/**
+ * A {@link DataVisitor} that visits a {@link DataContainer} and returns the value of the key
+ * This class uses Class#isInstance to check if the value is of the correct type in the resource.
+ *
+ * @param <T> The type of the value you want to extract
+ */
+public class ClassBasedVisitor<T> implements DataVisitor<T> {
 	private final Class<T> type;
 	private final String key;
 
@@ -11,12 +20,44 @@ public class ClassBasedVisitor<T> implements DataVisitor<T>{
 		this.key = key;
 	}
 
+	/**
+	 * Visits a container and returns the value of the key if it is of the correct type.
+	 * Will also check if the value is a list and return the first element if it is of the correct type.
+	 *
+	 * @param dataContainer the container to visit
+	 * @return the value of the key if it is of the correct type
+	 */
 	@Override
 	public Optional<T> visit(DataContainer dataContainer) {
-		if(dataContainer instanceof CustomJsonDataContainer customJsonDataContainer){
+		if (dataContainer instanceof CustomJsonDataContainer customJsonDataContainer) {
 			return customJsonDataContainer.getObject(key(), type);
 		}
-		return Optional.empty();
+		return visitMultiple(dataContainer).stream().findFirst();
+	}
+
+	/**
+	 * Visits a container and returns all values of the key if they are of the correct type.
+	 *
+	 * @param dataContainer the container to visit
+	 * @return all values of the key if they are of the correct type
+	 */
+	@Override
+	public List<T> visitMultiple(DataContainer dataContainer) {
+		if (dataContainer instanceof CustomJsonDataContainer customJsonDataContainer) {
+			List<T> results = customJsonDataContainer.getObject(key(), List.class)
+					.map(list -> (List<?>) list)
+					.orElse(Collections.emptyList())
+					.stream()
+					.filter(type::isInstance)
+					.map(type::cast)
+					.collect(Collectors.toList());
+
+			if (results.isEmpty()) {
+				visit(dataContainer).ifPresent(results::add);
+			}
+			return results;
+		}
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ClassBasedVisitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ClassBasedVisitor.java
@@ -1,0 +1,26 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import java.util.Optional;
+
+public class ClassBasedVisitor<T> implements DataVisitor<T>{
+	private final Class<T> type;
+	private final String key;
+
+	public ClassBasedVisitor(Class<T> type, String key) {
+		this.type = type;
+		this.key = key;
+	}
+
+	@Override
+	public Optional<T> visit(DataContainer dataContainer) {
+		if(dataContainer instanceof CustomJsonDataContainer customJsonDataContainer){
+			return customJsonDataContainer.getObject(key(), type);
+		}
+		return Optional.empty();
+	}
+
+	@Override
+	public String key() {
+		return key;
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CommonTags.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CommonTags.java
@@ -1,6 +1,8 @@
 package com.sigmundgranaas.forgero.core.customdata;
 
+/**
+ * Common tags used in custom data fields
+ */
 public class CommonTags {
 	public static final String INGREDIENT_COUNT = "ingredient_count";
-
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CommonTags.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CommonTags.java
@@ -1,0 +1,6 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+public class CommonTags {
+	public static final String INGREDIENT_COUNT = "ingredient_count";
+
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContainerVisitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContainerVisitor.java
@@ -2,6 +2,11 @@ package com.sigmundgranaas.forgero.core.customdata;
 
 import java.util.Optional;
 
+/**
+ * A visitor for {@link DataContainer}s.
+ * <p>
+ * Will check visitable objects for {@link DataSupplier} and return the custom data.
+ */
 public class ContainerVisitor implements Visitor<DataContainer> {
 	public static ContainerVisitor VISITOR = new ContainerVisitor();
 

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContainerVisitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContainerVisitor.java
@@ -1,0 +1,15 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import java.util.Optional;
+
+public class ContainerVisitor implements Visitor<DataContainer> {
+	public static ContainerVisitor VISITOR = new ContainerVisitor();
+
+	@Override
+	public Optional<DataContainer> visit(Visitable visitable) {
+		if (visitable instanceof DataSupplier supplier) {
+			return Optional.of(supplier.customData());
+		}
+		return Optional.empty();
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContainerVisitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContainerVisitor.java
@@ -17,4 +17,6 @@ public class ContainerVisitor implements Visitor<DataContainer> {
 		}
 		return Optional.empty();
 	}
+
+
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Context.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Context.java
@@ -1,5 +1,11 @@
 package com.sigmundgranaas.forgero.core.customdata;
 
+/**
+ * The context of a custom data field.
+ * Local means that the field is only available in the resource it was declared in.
+ * <p>
+ * Transitive means that the field is available in all resources that inherit from the resource it was declared in.
+ */
 public enum Context {
 	LOCAL,
 	TRANSITIVE

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Context.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Context.java
@@ -1,0 +1,6 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+public enum Context {
+	LOCAL,
+	TRANSITIVE
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContextAwareData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContextAwareData.java
@@ -1,0 +1,19 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+public class ContextAwareData<T> {
+	private final T value;
+	private Context context = Context.TRANSITIVE;
+
+	public ContextAwareData(Context context, T value) {
+		this.context = context;
+		this.value = value;
+	}
+
+	public Context context() {
+		return context;
+	}
+
+	public T value() {
+		return value;
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContextAwareData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContextAwareData.java
@@ -1,7 +1,16 @@
 package com.sigmundgranaas.forgero.core.customdata;
 
+/**
+ * A data object that uses a context.
+ * The context is used to determine whether the data is available in all resources that inherit from the resource it was declared in.
+ * <p>
+ * Will default to using transitively available data.
+ *
+ * @param <T> Any custom data
+ */
 public class ContextAwareData<T> {
 	private final T value;
+	@SuppressWarnings("UnusedAssignment")
 	private Context context = Context.TRANSITIVE;
 
 	public ContextAwareData(Context context, T value) {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContextAwareData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/ContextAwareData.java
@@ -1,5 +1,7 @@
 package com.sigmundgranaas.forgero.core.customdata;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * A data object that uses a context.
  * The context is used to determine whether the data is available in all resources that inherit from the resource it was declared in.
@@ -9,11 +11,12 @@ package com.sigmundgranaas.forgero.core.customdata;
  * @param <T> Any custom data
  */
 public class ContextAwareData<T> {
+	@Nullable
 	private final T value;
 	@SuppressWarnings("UnusedAssignment")
 	private Context context = Context.TRANSITIVE;
 
-	public ContextAwareData(Context context, T value) {
+	public ContextAwareData(Context context, @Nullable T value) {
 		this.context = context;
 		this.value = value;
 	}
@@ -22,6 +25,7 @@ public class ContextAwareData<T> {
 		return context;
 	}
 
+	@Nullable
 	public T value() {
 		return value;
 	}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CustomJsonDataContainer.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CustomJsonDataContainer.java
@@ -1,0 +1,104 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+
+public class CustomJsonDataContainer implements DataContainer {
+	private final Map<String, JsonElement> customData;
+
+	public CustomJsonDataContainer(Map<String, JsonElement> customData) {
+		this.customData = customData;
+	}
+
+	public static DataContainer of(Map<String, JsonElement> customData) {
+		return new CustomJsonDataContainer(customData);
+	}
+
+	@Override
+	public Optional<Integer> getInteger(String key) {
+		return simpleValues(key, Integer.class);
+	}
+
+	@Override
+	public Optional<Float> getFloat(String key) {
+		return simpleValues(key, Float.class);
+	}
+
+	@Override
+	public Optional<String> getString(String key) {
+		return simpleValues(key, String.class);
+	}
+
+	@Override
+	public Optional<Boolean> getBoolean(String key) {
+		return simpleValues(key, Boolean.class);
+	}
+
+	private <T> Optional<T> simpleValues(String key, Class<T> type) {
+		Optional<T> element = getObject(key, type);
+		if (element.isPresent()) {
+			return element;
+		} else {
+			return contextValue(key, type).map(ContextAwareData::value);
+		}
+	}
+
+	private <T> Optional<ContextAwareData<T>> contextValue(String key, Class<T> type) {
+		var dataOptional = getObject(key, ContextAwareData.class);
+		if (dataOptional.isPresent()) {
+			var data = dataOptional.get();
+			return convertFromJsonElement(new Gson().toJsonTree(data.value()), type).map(value -> new ContextAwareData<>(data.context(), value));
+		}
+		return Optional.empty();
+	}
+
+	public <T> Optional<T> getObject(String key, Class<T> type) {
+		Optional<JsonElement> element = Optional.ofNullable(customData.get(key));
+		if (element.isEmpty()) {
+			return Optional.empty();
+		}
+		return convertFromJsonElement(element.get(), type);
+	}
+
+	private <T> Optional<T> convertFromJsonElement(JsonElement element, Class<T> type) {
+		try {
+			return Optional.of(new Gson().fromJson(element, type));
+		} catch (JsonSyntaxException e) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public CustomJsonDataContainer merge(DataContainer other) {
+		if (other instanceof CustomJsonDataContainer customJsonDataContainer) {
+			Map<String, JsonElement> combinedMap = ImmutableMap.<String, JsonElement>builder()
+					.putAll(customData)
+					.putAll(customJsonDataContainer.getCustomData())
+					.build();
+			return new CustomJsonDataContainer(combinedMap);
+		}
+		return this;
+	}
+
+	@Override
+	public DataContainer merge(DataContainer other, Context context) {
+		var filteredValues = merge(other).customData.entrySet().stream()
+				.filter(entry -> isRightContext(entry, context))
+				.collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+		return new CustomJsonDataContainer(filteredValues);
+	}
+
+	private boolean isRightContext(Map.Entry<String, JsonElement> entry, Context context) {
+		var convertedValue = contextValue(entry.getKey(), Object.class);
+		return convertedValue.map(objectContextAwareData -> objectContextAwareData.context() == context).orElse(true);
+	}
+
+	protected Map<String, JsonElement> getCustomData() {
+		return customData;
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CustomJsonDataContainer.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CustomJsonDataContainer.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A custom data container that uses a {@link Map} to store data.
+ * A custom data container that uses a Json data to store custom resources.
  * Will store data as JsonData.
  * <p>
  * Can be used to store custom data in a {@link DataSupplier}.

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CustomJsonDataContainer.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/CustomJsonDataContainer.java
@@ -79,7 +79,19 @@ public class CustomJsonDataContainer implements DataContainer {
 		var dataOptional = getObject(key, ContextAwareData.class);
 		if (dataOptional.isPresent()) {
 			var data = dataOptional.get();
-			return convertFromJsonElement(new Gson().toJsonTree(data.value()), type).map(value -> new ContextAwareData<>(data.context(), value));
+			var converted = convertFromJsonElement(new Gson().toJsonTree(data.value()), type).map(value -> new ContextAwareData<>(data.context(), value));
+			if (converted.isEmpty()) {
+				if (customData.containsKey(key)) {
+					var element = customData.get(key);
+					if (element.isJsonObject() && element.getAsJsonObject().has("context")) {
+						var context = element.getAsJsonObject().get("context").getAsString();
+						return Optional.of(new ContextAwareData<>(Context.valueOf(context), null));
+					}
+				}
+				return converted;
+			}
+
+			return converted;
 		}
 		return Optional.empty();
 	}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataContainer.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataContainer.java
@@ -2,6 +2,15 @@ package com.sigmundgranaas.forgero.core.customdata;
 
 import java.util.Optional;
 
+/**
+ * A container for custom data.
+ * Will be used to store custom data for resources.
+ * <p>
+ * Containers will be merged when resources are inherited.
+ *
+ * @see DataVisitor for how to extract data from a container.
+ * @see DataSupplier for how to get a container from a resource.
+ */
 public interface DataContainer {
 	static DataContainer empty() {
 		return new EmptyContainer();

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataContainer.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataContainer.java
@@ -1,0 +1,29 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import java.util.Optional;
+
+public interface DataContainer {
+	static DataContainer empty() {
+		return new EmptyContainer();
+	}
+
+	static DataContainer transitiveMerge(DataContainer a, DataContainer b) {
+		return a.merge(b, Context.TRANSITIVE);
+	}
+
+	Optional<Integer> getInteger(String key);
+
+	Optional<Float> getFloat(String key);
+
+	Optional<String> getString(String key);
+
+	Optional<Boolean> getBoolean(String key);
+
+	default <T> Optional<T> accept(DataVisitor<T> visitor) {
+		return visitor.visit(this);
+	}
+
+	DataContainer merge(DataContainer other);
+
+	DataContainer merge(DataContainer other, Context context);
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataContainer.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataContainer.java
@@ -2,6 +2,8 @@ package com.sigmundgranaas.forgero.core.customdata;
 
 import java.util.Optional;
 
+import com.sigmundgranaas.forgero.core.property.Target;
+
 /**
  * A container for custom data.
  * Will be used to store custom data for resources.
@@ -16,8 +18,8 @@ public interface DataContainer {
 		return new EmptyContainer();
 	}
 
-	static DataContainer transitiveMerge(DataContainer a, DataContainer b) {
-		return a.merge(b, Context.TRANSITIVE);
+	static DataContainer transitiveMerge(DataContainer a, DataContainer b, Target target) {
+		return a.merge(b, Context.TRANSITIVE, target);
 	}
 
 	Optional<Integer> getInteger(String key);
@@ -34,5 +36,6 @@ public interface DataContainer {
 
 	DataContainer merge(DataContainer other);
 
-	DataContainer merge(DataContainer other, Context context);
+	//TODO: remove target in favour of a better context solution
+	DataContainer merge(DataContainer other, Context context, Target target);
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataSupplier.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataSupplier.java
@@ -1,0 +1,10 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+@FunctionalInterface
+public interface DataSupplier {
+	DataContainer customData();
+
+	default boolean hasData() {
+		return !(customData() instanceof EmptyContainer);
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataSupplier.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataSupplier.java
@@ -1,5 +1,7 @@
 package com.sigmundgranaas.forgero.core.customdata;
 
+import com.sigmundgranaas.forgero.core.property.Target;
+
 /**
  * A supplier of custom data.
  * <p>
@@ -8,11 +10,16 @@ package com.sigmundgranaas.forgero.core.customdata;
  *
  * @see DataContainer
  */
-@FunctionalInterface
 public interface DataSupplier {
-	DataContainer customData();
+	default DataContainer customData(Target target) {
+		return customData();
+	}
+
+	default DataContainer customData() {
+		return customData(Target.EMPTY);
+	}
 
 	default boolean hasData() {
-		return !(customData() instanceof EmptyContainer);
+		return !(customData(Target.EMPTY) instanceof EmptyContainer);
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataSupplier.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataSupplier.java
@@ -1,5 +1,13 @@
 package com.sigmundgranaas.forgero.core.customdata;
 
+/**
+ * A supplier of custom data.
+ * <p>
+ * For customData to be updatable, data container must be supplied when requested.
+ * This makes it possible to reload data without restarting the game.
+ *
+ * @see DataContainer
+ */
 @FunctionalInterface
 public interface DataSupplier {
 	DataContainer customData();

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataVisitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataVisitor.java
@@ -1,13 +1,35 @@
 package com.sigmundgranaas.forgero.core.customdata;
 
+import java.util.List;
 import java.util.Optional;
 
+/**
+ * A visitor for {@link DataContainer}s.
+ * <p>
+ * This interface is used to check if a {@link DataContainer} contains a specific type of data.
+ * Used to extract custom_data declared in resource files.
+ * <p>
+ * Example:
+ * <pre>
+ *     {@code
+ *     "custom_data": {
+ *          "ingredient_count": 2,
+ *          "better_compat_attribute_container": "bettercombat:cutlass"
+ *          }
+ *     }
+ * </pre>
+ *
+ * @param <T> the type of data to visit
+ *            The visitors support primitive types, lists as well as custom classes.
+ */
 public interface DataVisitor<T> {
-	Optional<T> visit(DataContainer dataContainer);
-
-	String key();
-
-	static <T> DataVisitor<T> of(Class<T> type, String key){
+	static <T> DataVisitor<T> of(Class<T> type, String key) {
 		return new ClassBasedVisitor<>(type, key);
 	}
+
+	Optional<T> visit(DataContainer dataContainer);
+
+	List<T> visitMultiple(DataContainer dataContainer);
+
+	String key();
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataVisitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/DataVisitor.java
@@ -1,0 +1,13 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import java.util.Optional;
+
+public interface DataVisitor<T> {
+	Optional<T> visit(DataContainer dataContainer);
+
+	String key();
+
+	static <T> DataVisitor<T> of(Class<T> type, String key){
+		return new ClassBasedVisitor<>(type, key);
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/EmptyContainer.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/EmptyContainer.java
@@ -2,6 +2,8 @@ package com.sigmundgranaas.forgero.core.customdata;
 
 import java.util.Optional;
 
+import com.sigmundgranaas.forgero.core.property.Target;
+
 /**
  * An empty data container. Used as a default value for custom data containers.
  */
@@ -32,7 +34,7 @@ public class EmptyContainer implements DataContainer {
 	}
 
 	@Override
-	public DataContainer merge(DataContainer other, Context context) {
+	public DataContainer merge(DataContainer other, Context context, Target target) {
 		return other;
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/EmptyContainer.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/EmptyContainer.java
@@ -1,0 +1,35 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import java.util.Optional;
+
+public class EmptyContainer implements DataContainer {
+	@Override
+	public Optional<Integer> getInteger(String key) {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<Float> getFloat(String key) {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<String> getString(String key) {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<Boolean> getBoolean(String key) {
+		return Optional.empty();
+	}
+
+	@Override
+	public DataContainer merge(DataContainer other) {
+		return other;
+	}
+
+	@Override
+	public DataContainer merge(DataContainer other, Context context) {
+		return other;
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/EmptyContainer.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/EmptyContainer.java
@@ -2,6 +2,9 @@ package com.sigmundgranaas.forgero.core.customdata;
 
 import java.util.Optional;
 
+/**
+ * An empty data container. Used as a default value for custom data containers.
+ */
 public class EmptyContainer implements DataContainer {
 	@Override
 	public Optional<Integer> getInteger(String key) {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/TargetData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/TargetData.java
@@ -1,0 +1,62 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.google.common.base.Enums;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.sigmundgranaas.forgero.core.property.Target;
+import com.sigmundgranaas.forgero.core.property.TargetTypes;
+
+public class TargetData {
+	private final Set<String> targets;
+
+	public TargetData(Set<String> targets) {
+		this.targets = targets;
+	}
+
+	public static TargetData of(Set<String> targets) {
+		return new TargetData(targets);
+	}
+
+	public static TargetData of() {
+		return new TargetData(Collections.emptySet());
+	}
+
+	public static TargetData of(JsonElement element) {
+		if (element.isJsonArray()) {
+			JsonArray array = element.getAsJsonArray();
+			var targets = IntStream.range(0, array.size()).mapToObj(i -> array.getAsString()).collect(Collectors.toSet());
+			return new TargetData(targets);
+		} else if (element.isJsonObject() && element.getAsJsonObject().has("targets")) {
+			return of(element.getAsJsonObject().get("targets"));
+		} else {
+			return new TargetData(Collections.emptySet());
+		}
+	}
+
+	public boolean isApplicable(Target target) {
+		//empty targets means that the data is always applicable
+		if (targets == null || targets.isEmpty()) {
+			return true;
+		}
+		return targets.stream().filter(this::isValid).anyMatch(id -> type(id).isPresent() && target.isApplicable(Set.of(strip(id)), type(id).get()));
+	}
+
+	public String strip(String target) {
+		return target.split(":")[1];
+	}
+
+	public Optional<TargetTypes> type(String target) {
+		var optionalType = Enums.getIfPresent(TargetTypes.class, target.split(":")[0]).toJavaUtil();
+		return optionalType.or(() -> Enums.getIfPresent(TargetTypes.class, target.split(":")[0].toUpperCase()).toJavaUtil());
+	}
+
+	public boolean isValid(String target) {
+		return target.split(":").length == 2 && type(target).isPresent();
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Visitable.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Visitable.java
@@ -1,0 +1,9 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import java.util.Optional;
+
+public interface Visitable {
+	default <T> Optional<T> accept(Visitor<T> visitor){
+		return visitor.visit(this);
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Visitable.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Visitable.java
@@ -2,8 +2,12 @@ package com.sigmundgranaas.forgero.core.customdata;
 
 import java.util.Optional;
 
+/**
+ * A visitable object. Will be used to provide a visitor pattern for custom data to keep central domain logic flexible.
+ * Classes can visit other classes to extract data, and handle them using custom logic to avoid tight coupling.
+ */
 public interface Visitable {
-	default <T> Optional<T> accept(Visitor<T> visitor){
+	default <T> Optional<T> accept(Visitor<T> visitor) {
 		return visitor.visit(this);
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Visitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Visitor.java
@@ -2,6 +2,13 @@ package com.sigmundgranaas.forgero.core.customdata;
 
 import java.util.Optional;
 
+/**
+ * A visitor for {@link Visitable}s.
+ * <p>
+ * See ContainerVisitor for an example.
+ *
+ * @param <T> the type of data to visit
+ */
 public interface Visitor<T> {
 	Optional<T> visit(Visitable visitable);
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Visitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/Visitor.java
@@ -1,0 +1,7 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import java.util.Optional;
+
+public interface Visitor<T> {
+	Optional<T> visit(Visitable visitable);
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/VisitorHelper.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/VisitorHelper.java
@@ -1,0 +1,25 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import static com.sigmundgranaas.forgero.core.customdata.ContainerVisitor.VISITOR;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class VisitorHelper {
+	/**
+	 * Accepts a visitor on a visitable object.
+	 * <p>
+	 * Will check visitable objects for {@link DataSupplier} and return the custom data.
+	 *
+	 * @param object  the object to visit
+	 * @param visitor the visitor to accept
+	 * @param <T>     the type of the visitor
+	 * @return the result of the visitor
+	 */
+	public static <T> Optional<T> of(Object object, Supplier<DataVisitor<T>> visitor) {
+		if (object instanceof Visitable visitable) {
+			return visitable.accept(VISITOR).flatMap(container -> container.accept(visitor.get()));
+		}
+		return Optional.empty();
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/handler/LootVisitor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/customdata/handler/LootVisitor.java
@@ -1,0 +1,65 @@
+package com.sigmundgranaas.forgero.core.customdata.handler;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import com.google.gson.annotations.SerializedName;
+import com.sigmundgranaas.forgero.core.customdata.ClassBasedVisitor;
+import com.sigmundgranaas.forgero.core.customdata.Context;
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
+import com.sigmundgranaas.forgero.core.customdata.DataVisitor;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+/**
+ * A {@link DataVisitor} for {@link CustomLootData}.
+ * {@link CustomLootData} is used to exclude resources from a loot table.
+ * <p>
+ * This visitor is used to extract {@link CustomLootData} from a {@link DataContainer}.
+ * It will check if a loot table is excluded from this resource.
+ */
+public class LootVisitor extends ClassBasedVisitor<LootVisitor.CustomLootData> {
+	public static final String KEY = "loot";
+
+	public LootVisitor() {
+		super(CustomLootData.class, KEY);
+	}
+
+	@Data
+	@Accessors(fluent = true)
+	public static class CustomLootData {
+		Context context = Context.LOCAL;
+		@SerializedName(value = "excluded_loot_tables", alternate = {"excludedLootTables", "excluded"})
+		Set<String> excludedLootTables = Collections.emptySet();
+		Set<String> onlyLootTables = Collections.emptySet();
+
+		/**
+		 * Checks if the loot table is excluded from this resource.
+		 *
+		 * @param lootTable the loot table to check
+		 * @return true if the loot table is excluded
+		 */
+		public boolean isExcluded(String lootTable) {
+			if (onlyLootTables.isEmpty()) {
+				if (excludedLootTables.isEmpty()) {
+					return false;
+				} else {
+					return excludedLootTables.contains(lootTable);
+				}
+			} else {
+				return !onlyLootTables.contains(lootTable);
+			}
+		}
+
+		/**
+		 * Checks if the loot table is excluded from this resource.
+		 *
+		 * @param lootTables the loot tables to check
+		 * @return true if the loot table is excluded
+		 */
+		public boolean isExcluded(Collection<String> lootTables) {
+			return lootTables.stream().anyMatch(this::isExcluded);
+		}
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DataResource.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DataResource.java
@@ -1,19 +1,27 @@
 package com.sigmundgranaas.forgero.core.resource.data.v2.data;
 
+import static com.sigmundgranaas.forgero.core.util.Identifiers.EMPTY_IDENTIFIER;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableList;
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
+import com.sigmundgranaas.forgero.core.customdata.CustomJsonDataContainer;
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.resource.data.PropertyPojo;
 import com.sigmundgranaas.forgero.core.resource.data.SchemaVersion;
 import com.sigmundgranaas.forgero.core.state.Identifiable;
 import lombok.Builder;
 import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nullable;
-
-import java.util.*;
-import java.util.stream.Stream;
-
-import static com.sigmundgranaas.forgero.core.util.Identifiers.EMPTY_IDENTIFIER;
 
 @Builder(toBuilder = true)
 public class DataResource implements Identifiable {
@@ -79,7 +87,7 @@ public class DataResource implements Identifiable {
 
 	@Builder.Default
 	@SerializedName("custom_data")
-	private Map<String, String> customData = new HashMap<>();
+	private Map<String, JsonElement> customData = new HashMap<>();
 
 	public static <T> List<T> mergeProperty(List<T> attribute1, List<T> attribute2) {
 		if (attribute1 == null && attribute2 == null)
@@ -194,7 +202,7 @@ public class DataResource implements Identifiable {
 		return builder.property(newProps).build();
 	}
 
-	public Map<String, String> getCustomData() {
-		return Objects.requireNonNullElse(customData, new HashMap<>());
+	public DataContainer getCustomData() {
+		return CustomJsonDataContainer.of(customData);
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/ConditionedState.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/ConditionedState.java
@@ -8,6 +8,7 @@ import com.sigmundgranaas.forgero.core.condition.Conditional;
 import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.Property;
 import com.sigmundgranaas.forgero.core.property.PropertyContainer;
+import com.sigmundgranaas.forgero.core.property.Target;
 import com.sigmundgranaas.forgero.core.type.Type;
 import com.sigmundgranaas.forgero.core.util.match.Context;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
@@ -84,7 +85,7 @@ public class ConditionedState implements State, Conditional<ConditionedState> {
 	}
 
 	@Override
-	public DataContainer customData() {
+	public DataContainer customData(Target target) {
 		return customData;
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/ConditionedState.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/ConditionedState.java
@@ -1,19 +1,18 @@
 package com.sigmundgranaas.forgero.core.state;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 import com.sigmundgranaas.forgero.core.condition.ConditionContainer;
 import com.sigmundgranaas.forgero.core.condition.Conditional;
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.Property;
 import com.sigmundgranaas.forgero.core.property.PropertyContainer;
-import com.sigmundgranaas.forgero.core.state.customvalue.CustomValue;
 import com.sigmundgranaas.forgero.core.type.Type;
 import com.sigmundgranaas.forgero.core.util.match.Context;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import com.sigmundgranaas.forgero.core.util.match.NameMatch;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
 
 public class ConditionedState implements State, Conditional<ConditionedState> {
 	private final IdentifiableContainer id;
@@ -21,9 +20,9 @@ public class ConditionedState implements State, Conditional<ConditionedState> {
 
 	private final List<Property> properties;
 
-	private final Map<String, CustomValue> customData;
+	private final DataContainer customData;
 
-	public ConditionedState(IdentifiableContainer id, ConditionContainer conditions, List<Property> properties, Map<String, CustomValue> customData) {
+	public ConditionedState(IdentifiableContainer id, ConditionContainer conditions, List<Property> properties, DataContainer customData) {
 		this.id = id;
 		this.conditions = conditions;
 		this.properties = properties;
@@ -32,7 +31,7 @@ public class ConditionedState implements State, Conditional<ConditionedState> {
 
 	public static ConditionedState of(State state) {
 		IdentifiableContainer id = new IdentifiableContainer(state.name(), state.nameSpace(), state.type());
-		return new ConditionedState(id, Conditional.EMPTY, state.getRootProperties(), state.customValues());
+		return new ConditionedState(id, Conditional.EMPTY, state.getRootProperties(), state.customData());
 	}
 
 	@Override
@@ -49,7 +48,6 @@ public class ConditionedState implements State, Conditional<ConditionedState> {
 	public ConditionedState removeCondition(String identifier) {
 		return new ConditionedState(id, conditions.removeCondition(identifier), properties, customData);
 	}
-
 
 	@Override
 	public String identifier() {
@@ -86,7 +84,7 @@ public class ConditionedState implements State, Conditional<ConditionedState> {
 	}
 
 	@Override
-	public Map<String, CustomValue> customValues() {
-		return this.customData;
+	public DataContainer customData() {
+		return customData;
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/EmptyState.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/EmptyState.java
@@ -1,6 +1,7 @@
 package com.sigmundgranaas.forgero.core.state;
 
 import com.sigmundgranaas.forgero.core.Forgero;
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.type.Type;
 
 public class EmptyState implements State {
@@ -20,5 +21,10 @@ public class EmptyState implements State {
 	@Override
 	public Type type() {
 		return Type.UNDEFINED;
+	}
+
+	@Override
+	public DataContainer customData() {
+		return DataContainer.empty();
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/EmptyState.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/EmptyState.java
@@ -2,6 +2,7 @@ package com.sigmundgranaas.forgero.core.state;
 
 import com.sigmundgranaas.forgero.core.Forgero;
 import com.sigmundgranaas.forgero.core.customdata.DataContainer;
+import com.sigmundgranaas.forgero.core.property.Target;
 import com.sigmundgranaas.forgero.core.type.Type;
 
 public class EmptyState implements State {
@@ -24,7 +25,7 @@ public class EmptyState implements State {
 	}
 
 	@Override
-	public DataContainer customData() {
+	public DataContainer customData(Target target) {
 		return DataContainer.empty();
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/LeveledState.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/LeveledState.java
@@ -1,5 +1,11 @@
 package com.sigmundgranaas.forgero.core.state;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.Attribute;
 import com.sigmundgranaas.forgero.core.property.Property;
 import com.sigmundgranaas.forgero.core.property.Target;
@@ -7,11 +13,6 @@ import com.sigmundgranaas.forgero.core.property.attribute.AttributeBuilder;
 import com.sigmundgranaas.forgero.core.type.Type;
 import lombok.Builder;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Builder(toBuilder = true)
 public class LeveledState implements State {
@@ -85,5 +86,10 @@ public class LeveledState implements State {
 				.nameSpace(nameSpace)
 				.type(type)
 				.build();
+	}
+
+	@Override
+	public DataContainer customData() {
+		return DataContainer.empty();
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/LeveledState.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/LeveledState.java
@@ -89,7 +89,7 @@ public class LeveledState implements State {
 	}
 
 	@Override
-	public DataContainer customData() {
+	public DataContainer customData(Target target) {
 		return DataContainer.empty();
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/SimpleState.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/SimpleState.java
@@ -8,6 +8,7 @@ import com.sigmundgranaas.forgero.core.condition.Conditional;
 import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.Property;
 import com.sigmundgranaas.forgero.core.property.PropertyContainer;
+import com.sigmundgranaas.forgero.core.property.Target;
 import com.sigmundgranaas.forgero.core.type.Type;
 import com.sigmundgranaas.forgero.core.util.match.Context;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
@@ -93,7 +94,7 @@ public final class SimpleState implements Ingredient, Conditional<State> {
 	}
 
 	@Override
-	public DataContainer customData() {
+	public DataContainer customData(Target target) {
 		return customData;
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/SimpleState.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/SimpleState.java
@@ -1,18 +1,18 @@
 package com.sigmundgranaas.forgero.core.state;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.sigmundgranaas.forgero.core.Forgero;
 import com.sigmundgranaas.forgero.core.condition.Conditional;
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.Property;
 import com.sigmundgranaas.forgero.core.property.PropertyContainer;
-import com.sigmundgranaas.forgero.core.state.customvalue.CustomValue;
 import com.sigmundgranaas.forgero.core.type.Type;
 import com.sigmundgranaas.forgero.core.util.match.Context;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import com.sigmundgranaas.forgero.core.util.match.NameMatch;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 @SuppressWarnings("ClassCanBeRecord")
 public final class SimpleState implements Ingredient, Conditional<State> {
@@ -20,14 +20,14 @@ public final class SimpleState implements Ingredient, Conditional<State> {
 	private final String nameSpace;
 	private final Type type;
 	private final List<Property> properties;
-	private final Map<String, CustomValue> customData;
+	private final DataContainer customData;
 
 	public SimpleState(String name, Type type, List<Property> properties) {
 		this.name = name;
 		this.type = type;
 		this.properties = properties;
 		this.nameSpace = Forgero.NAMESPACE;
-		this.customData = new HashMap<>();
+		this.customData = DataContainer.empty();
 	}
 
 	public SimpleState(String name, String nameSpace, Type type, List<Property> properties) {
@@ -35,15 +35,15 @@ public final class SimpleState implements Ingredient, Conditional<State> {
 		this.nameSpace = nameSpace;
 		this.type = type;
 		this.properties = properties;
-		this.customData = new HashMap<>();
+		this.customData = DataContainer.empty();
 	}
 
-	public SimpleState(String name, String nameSpace, Type type, List<Property> properties, Map<String, String> custom) {
+	public SimpleState(String name, String nameSpace, Type type, List<Property> properties, DataContainer custom) {
 		this.name = name;
 		this.nameSpace = nameSpace;
 		this.type = type;
 		this.properties = properties;
-		this.customData = custom.entrySet().stream().collect(Collectors.toMap((Map.Entry::getKey), (keyPair -> CustomValue.of(keyPair.getKey(), keyPair.getValue()))));
+		this.customData = custom;
 	}
 
 	@Override
@@ -78,19 +78,6 @@ public final class SimpleState implements Ingredient, Conditional<State> {
 	}
 
 	@Override
-	public Optional<CustomValue> getCustomValue(String identifier) {
-		if (customData.containsKey(identifier)) {
-			return Optional.of(customData.get(identifier));
-		}
-		return Optional.empty();
-	}
-
-	@Override
-	public Map<String, CustomValue> customValues() {
-		return this.customData;
-	}
-
-	@Override
 	public List<PropertyContainer> conditions() {
 		return Collections.emptyList();
 	}
@@ -103,5 +90,10 @@ public final class SimpleState implements Ingredient, Conditional<State> {
 	@Override
 	public State removeCondition(String identifier) {
 		return this;
+	}
+
+	@Override
+	public DataContainer customData() {
+		return customData;
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/State.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/State.java
@@ -24,11 +24,11 @@ public interface State extends PropertyContainer, Matchable, Identifiable, Compa
 		return new SimpleState(name, type, properties);
 	}
 
-	static Ingredient of(String name, String nameSpace, Type type, List<Property> properties) {
+	static State of(String name, String nameSpace, Type type, List<Property> properties) {
 		return new SimpleState(name, nameSpace, type, properties);
 	}
 
-	static Ingredient of(String name, String nameSpace, Type type, List<Property> properties, DataContainer custom) {
+	static State of(String name, String nameSpace, Type type, List<Property> properties, DataContainer custom) {
 		return new SimpleState(name, nameSpace, type, properties, custom);
 	}
 

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/State.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/State.java
@@ -1,21 +1,21 @@
 package com.sigmundgranaas.forgero.core.state;
 
+import java.util.List;
+
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
+import com.sigmundgranaas.forgero.core.customdata.DataSupplier;
+import com.sigmundgranaas.forgero.core.customdata.Visitable;
 import com.sigmundgranaas.forgero.core.property.Property;
 import com.sigmundgranaas.forgero.core.property.PropertyContainer;
 import com.sigmundgranaas.forgero.core.state.composite.Construct;
-import com.sigmundgranaas.forgero.core.state.customvalue.CustomValue;
 import com.sigmundgranaas.forgero.core.type.Type;
 import com.sigmundgranaas.forgero.core.util.match.Context;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import com.sigmundgranaas.forgero.core.util.match.NameMatch;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
-public interface State extends PropertyContainer, Matchable, Identifiable, Comparable<Object>, Typed {
+public interface State extends PropertyContainer, Matchable, Identifiable, Comparable<Object>, Typed, Visitable, DataSupplier {
 	static State of(Construct construct) {
 		return new CompositeIngredient(construct);
 	}
@@ -28,7 +28,7 @@ public interface State extends PropertyContainer, Matchable, Identifiable, Compa
 		return new SimpleState(name, nameSpace, type, properties);
 	}
 
-	static Ingredient of(String name, String nameSpace, Type type, List<Property> properties, Map<String, String> custom) {
+	static Ingredient of(String name, String nameSpace, Type type, List<Property> properties, DataContainer custom) {
 		return new SimpleState(name, nameSpace, type, properties, custom);
 	}
 
@@ -61,17 +61,5 @@ public interface State extends PropertyContainer, Matchable, Identifiable, Compa
 		} else {
 			return 0;
 		}
-	}
-
-	default boolean hasCustomValue(String identifier) {
-		return getCustomValue(identifier).isPresent();
-	}
-
-	default Optional<CustomValue> getCustomValue(String identifier) {
-		return Optional.ofNullable(customValues().get(identifier));
-	}
-
-	default Map<String, CustomValue> customValues() {
-		return Collections.emptyMap();
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/Construct.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/Construct.java
@@ -1,8 +1,22 @@
 package com.sigmundgranaas.forgero.core.state.composite;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import com.google.common.collect.ImmutableList;
 import com.sigmundgranaas.forgero.core.Forgero;
-import com.sigmundgranaas.forgero.core.property.*;
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
+import com.sigmundgranaas.forgero.core.property.Attribute;
+import com.sigmundgranaas.forgero.core.property.AttributeType;
+import com.sigmundgranaas.forgero.core.property.CalculationOrder;
+import com.sigmundgranaas.forgero.core.property.NumericOperation;
+import com.sigmundgranaas.forgero.core.property.Property;
+import com.sigmundgranaas.forgero.core.property.Target;
 import com.sigmundgranaas.forgero.core.property.attribute.AttributeBuilder;
 import com.sigmundgranaas.forgero.core.property.attribute.Category;
 import com.sigmundgranaas.forgero.core.property.attribute.TypeTarget;
@@ -15,10 +29,6 @@ import com.sigmundgranaas.forgero.core.util.match.Context;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import com.sigmundgranaas.forgero.core.util.match.NameMatch;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @SuppressWarnings("ClassCanBeRecord")
 public class Construct implements Composite, ConstructedState {
@@ -265,6 +275,11 @@ public class Construct implements Composite, ConstructedState {
 	@Override
 	public Composite copy() {
 		return toBuilder().build();
+	}
+
+	@Override
+	public DataContainer customData() {
+		return components().stream().map(State::customData).reduce(DataContainer.empty(), DataContainer::transitiveMerge);
 	}
 
 	public static class ConstructBuilder extends BaseComposite.BaseCompositeBuilder<ConstructBuilder> {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/Construct.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/Construct.java
@@ -278,8 +278,9 @@ public class Construct implements Composite, ConstructedState {
 	}
 
 	@Override
-	public DataContainer customData() {
-		return components().stream().map(State::customData).reduce(DataContainer.empty(), DataContainer::transitiveMerge);
+	public DataContainer customData(Target target) {
+		var combinedTarget = target.combineTarget(new TypeTarget(Set.of(type().typeName())));
+		return components().stream().map(state -> state.customData(combinedTarget)).reduce(DataContainer.empty(), (dataContainer1, dataContainer2) -> DataContainer.transitiveMerge(dataContainer1, dataContainer2, combinedTarget));
 	}
 
 	public static class ConstructBuilder extends BaseComposite.BaseCompositeBuilder<ConstructBuilder> {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/ConstructedComposite.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/ConstructedComposite.java
@@ -152,8 +152,9 @@ public class ConstructedComposite extends BaseComposite implements ConstructedSt
 	}
 
 	@Override
-	public DataContainer customData() {
-		return components().stream().map(State::customData).reduce(DataContainer.empty(), DataContainer::transitiveMerge);
+	public DataContainer customData(Target target) {
+		var combinedTarget = target.combineTarget(new TypeTarget(Set.of(type().typeName())));
+		return components().stream().map(state -> state.customData(combinedTarget)).reduce(DataContainer.empty(), (dataContainer1, dataContainer2) -> DataContainer.transitiveMerge(dataContainer1, dataContainer2, combinedTarget));
 	}
 
 	public static class ConstructBuilder extends BaseCompositeBuilder<ConstructBuilder> {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/ConstructedComposite.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/ConstructedComposite.java
@@ -1,6 +1,21 @@
 package com.sigmundgranaas.forgero.core.state.composite;
 
-import com.sigmundgranaas.forgero.core.property.*;
+import static com.sigmundgranaas.forgero.core.state.composite.ConstructedComposite.ConstructBuilder.builder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
+import com.sigmundgranaas.forgero.core.property.Attribute;
+import com.sigmundgranaas.forgero.core.property.AttributeType;
+import com.sigmundgranaas.forgero.core.property.CalculationOrder;
+import com.sigmundgranaas.forgero.core.property.NumericOperation;
+import com.sigmundgranaas.forgero.core.property.Property;
+import com.sigmundgranaas.forgero.core.property.Target;
 import com.sigmundgranaas.forgero.core.property.attribute.AttributeBuilder;
 import com.sigmundgranaas.forgero.core.property.attribute.Category;
 import com.sigmundgranaas.forgero.core.property.attribute.TypeTarget;
@@ -12,15 +27,6 @@ import com.sigmundgranaas.forgero.core.util.match.Context;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import com.sigmundgranaas.forgero.core.util.match.NameMatch;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static com.sigmundgranaas.forgero.core.state.composite.ConstructedComposite.ConstructBuilder.builder;
 
 public class ConstructedComposite extends BaseComposite implements ConstructedState {
 	private final List<State> parts;
@@ -76,9 +82,7 @@ public class ConstructedComposite extends BaseComposite implements ConstructedSt
 		if (property instanceof Attribute attribute) {
 			if (Category.UPGRADE_CATEGORIES.contains(attribute.getCategory())) {
 				return false;
-			} else if (attribute.getOrder() == CalculationOrder.COMPOSITE) {
-				return false;
-			}
+			} else return attribute.getOrder() != CalculationOrder.COMPOSITE;
 		}
 		return true;
 	}
@@ -145,6 +149,11 @@ public class ConstructedComposite extends BaseComposite implements ConstructedSt
 	@Override
 	public ConstructedComposite copy() {
 		return toBuilder().build();
+	}
+
+	@Override
+	public DataContainer customData() {
+		return components().stream().map(State::customData).reduce(DataContainer.empty(), DataContainer::transitiveMerge);
 	}
 
 	public static class ConstructBuilder extends BaseCompositeBuilder<ConstructBuilder> {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/StaticComposite.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/StaticComposite.java
@@ -1,6 +1,12 @@
 package com.sigmundgranaas.forgero.core.state.composite;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
 import com.google.common.collect.ImmutableList;
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.Attribute;
 import com.sigmundgranaas.forgero.core.property.Property;
 import com.sigmundgranaas.forgero.core.property.PropertyContainer;
@@ -16,11 +22,6 @@ import com.sigmundgranaas.forgero.core.util.match.Context;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import com.sigmundgranaas.forgero.core.util.match.NameMatch;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
 
 public class StaticComposite implements Composite {
 	private final SlotContainer upgrades;
@@ -128,5 +129,10 @@ public class StaticComposite implements Composite {
 	@Override
 	public Composite copy() {
 		return this;
+	}
+
+	@Override
+	public DataContainer customData() {
+		return DataContainer.empty();
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/StaticComposite.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/StaticComposite.java
@@ -132,7 +132,7 @@ public class StaticComposite implements Composite {
 	}
 
 	@Override
-	public DataContainer customData() {
+	public DataContainer customData(Target target) {
 		return DataContainer.empty();
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/upgrade/SimpleUpgrade.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/upgrade/SimpleUpgrade.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.Property;
+import com.sigmundgranaas.forgero.core.property.Target;
 import com.sigmundgranaas.forgero.core.state.Upgrade;
 import com.sigmundgranaas.forgero.core.type.Type;
 import com.sigmundgranaas.forgero.core.util.match.Context;
@@ -49,7 +50,7 @@ public class SimpleUpgrade implements Upgrade {
 	}
 
 	@Override
-	public DataContainer customData() {
+	public DataContainer customData(Target target) {
 		return DataContainer.empty();
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/upgrade/SimpleUpgrade.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/upgrade/SimpleUpgrade.java
@@ -1,13 +1,14 @@
 package com.sigmundgranaas.forgero.core.state.upgrade;
 
+import java.util.List;
+
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
 import com.sigmundgranaas.forgero.core.property.Property;
 import com.sigmundgranaas.forgero.core.state.Upgrade;
 import com.sigmundgranaas.forgero.core.type.Type;
 import com.sigmundgranaas.forgero.core.util.match.Context;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
 
 public class SimpleUpgrade implements Upgrade {
 	private final String name;
@@ -45,5 +46,10 @@ public class SimpleUpgrade implements Upgrade {
 	@Override
 	public Type type() {
 		return type;
+	}
+
+	@Override
+	public DataContainer customData() {
+		return DataContainer.empty();
 	}
 }

--- a/forgero-core/src/test/java/com/sigmundgranaas/forgero/core/customdata/ContainerVisitorTest.java
+++ b/forgero-core/src/test/java/com/sigmundgranaas/forgero/core/customdata/ContainerVisitorTest.java
@@ -1,0 +1,62 @@
+package com.sigmundgranaas.forgero.core.customdata;
+
+import static com.sigmundgranaas.forgeroforge.testutil.Materials.IRON;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.sigmundgranaas.forgero.core.state.State;
+import com.sigmundgranaas.forgero.core.state.composite.ConstructedSchematicPart;
+import com.sigmundgranaas.forgero.core.type.Type;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ContainerVisitorTest {
+
+	@Test
+	void stateCanContainPrimitives() {
+		var map = new HashMap<String, JsonElement>();
+		map.put("ingredient_count", new JsonPrimitive(1));
+		State schematic = State.of("schematic", "forgero", Type.SCHEMATIC, Collections.emptyList(), new CustomJsonDataContainer(map));
+
+		var result = schematic.accept(ContainerVisitor.VISITOR)
+				.flatMap(container -> container.accept(new ClassBasedVisitor<>(Integer.class, "ingredient_count")));
+		Assertions.assertTrue(result.isPresent());
+		Assertions.assertEquals(1, result.get());
+	}
+
+	@Test
+	void canUseContextedObjects() {
+		var map = new HashMap<String, JsonElement>();
+		var jsonObject = new JsonObject();
+		jsonObject.addProperty("context", "LOCAL");
+		jsonObject.addProperty("value", 2);
+		map.put("ingredient_count", jsonObject);
+		State schematic = State.of("schematic", "forgero", Type.SCHEMATIC, Collections.emptyList(), new CustomJsonDataContainer(map));
+
+		var result = schematic.accept(ContainerVisitor.VISITOR)
+				.flatMap(container -> container.accept(new ClassBasedVisitor<>(ContextAwareData.class, "ingredient_count")));
+		Assertions.assertTrue(result.isPresent());
+		Assertions.assertEquals(2.0, result.get().value());
+	}
+
+	@Test
+	void localObjectsWillNotBeTransferred() {
+		var map = new HashMap<String, JsonElement>();
+		var jsonObject = new JsonObject();
+		jsonObject.addProperty("context", "LOCAL");
+		jsonObject.addProperty("value", 2);
+		map.put("ingredient_count", jsonObject);
+		State schematic = State.of("schematic", "forgero", Type.SCHEMATIC, Collections.emptyList(), new CustomJsonDataContainer(map));
+
+		ConstructedSchematicPart part = new ConstructedSchematicPart.SchematicPartBuilder(schematic, IRON).build();
+
+
+		var result = part.accept(ContainerVisitor.VISITOR)
+				.flatMap(container -> container.accept(new ClassBasedVisitor<>(ContextAwareData.class, "ingredient_count")));
+		Assertions.assertTrue(result.isEmpty());
+	}
+}


### PR DESCRIPTION
Reimplements the customResource system. The new system relies on handlers defining their own types to parse data. This makes the core module quite small and flexible and makes it possible to implement any kind of data as longs as there's an implementation that handles it.

closes #466 
closes #483 

TODO:
- [x] Implement the rest of the properties from #483 
- [x] Fix the rest of the schematic_material requirements
- [x] Add tests to make sure the system works as intended.
- [x] Add a better system to handle conditions