### PR TITLE
Simplify disassembly station recipe, and use tags instead of items

### DIFF
--- a/fabric/forgero-fabric-core/src/main/resources/data/c/tags/items/workbenches.json
+++ b/fabric/forgero-fabric-core/src/main/resources/data/c/tags/items/workbenches.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:crafting_table"
+  ]
+}

--- a/fabric/forgero-fabric-core/src/main/resources/data/forgero/recipes/assembly_table.json
+++ b/fabric/forgero-fabric-core/src/main/resources/data/forgero/recipes/assembly_table.json
@@ -1,22 +1,20 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    " x ",
-    "yyy",
-    "yzy"
+    "   ",
+    "xxx",
+    "xyx"
   ],
   "key": {
     "x": {
-      "tag": "forgero:schematic"
+      "tag": "minecraft:stone_tool_materials"
     },
     "y": {
-      "item": "minecraft:deepslate"
-    },
-    "z": {
-      "item": "minecraft:crafting_table"
+      "tag": "c:workbenches"
     }
   },
   "result": {
-    "item": "forgero:assembly_station"
+    "item": "forgero:assembly_station",
+    "count": 1
   }
 }


### PR DESCRIPTION
Uses the `c:workbenches` tag instead of the `minecraft:crafting_table` item. Also uses the `minecraft:stone_tool_materials` tag instead of deepslate, and removes schematics from the recipe.