### PR TITLE
Fix occasional `null` config crash

### DIFF
--- a/content/forgero-extended/src/test/java/com/sigmundgranaas/forgeroforge/test/util/ForgeroPipeLineSetup.java
+++ b/content/forgero-extended/src/test/java/com/sigmundgranaas/forgeroforge/test/util/ForgeroPipeLineSetup.java
@@ -6,6 +6,7 @@ import com.sigmundgranaas.forgero.core.resource.PipelineBuilder;
 import com.sigmundgranaas.forgero.core.resource.data.v2.PackageSupplier;
 import com.sigmundgranaas.forgero.core.resource.data.v2.packages.FilePackageLoader;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import static com.sigmundgranaas.forgero.core.ForgeroStateRegistry.*;
@@ -18,7 +19,7 @@ public class ForgeroPipeLineSetup {
 
 	public static void setup() {
 		if (ForgeroStateRegistry.COMPOSITES == null) {
-			ForgeroConfigurationLoader.load();
+			ForgeroConfigurationLoader.load(Path.of("config"));
 			PipelineBuilder
 					.builder()
 					.register(VANILLA_SUPPLIER)

--- a/content/forgero-vanilla/src/test/java/com/sigmundgranaas/forgeroforge/test/util/ForgeroPipeLineSetup.java
+++ b/content/forgero-vanilla/src/test/java/com/sigmundgranaas/forgeroforge/test/util/ForgeroPipeLineSetup.java
@@ -5,6 +5,7 @@ import com.sigmundgranaas.forgero.core.configuration.ForgeroConfigurationLoader;
 import com.sigmundgranaas.forgero.core.resource.PipelineBuilder;
 import com.sigmundgranaas.forgero.core.resource.data.v2.packages.FilePackageLoader;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import static com.sigmundgranaas.forgero.core.ForgeroStateRegistry.*;
@@ -15,7 +16,7 @@ public class ForgeroPipeLineSetup {
 
 	public static void setup() {
 		if (ForgeroStateRegistry.COMPOSITES == null) {
-			ForgeroConfigurationLoader.load();
+			ForgeroConfigurationLoader.load(Path.of("config"));
 			PipelineBuilder
 					.builder()
 					.register(() -> List.of(new FilePackageLoader(MINECRAFT_PACKAGE).get(), new FilePackageLoader(VANILLA_PACKAGE).get()))

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/modmenu/ForgeroConfigurationScreen.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/modmenu/ForgeroConfigurationScreen.java
@@ -1,12 +1,13 @@
 package com.sigmundgranaas.forgero.fabric.modmenu;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.sigmundgranaas.forgero.core.configuration.ForgeroConfigurationLoader;
 import com.sigmundgranaas.forgero.fabric.modmenu.gui.ConfigurationEntry;
 import com.sigmundgranaas.forgero.fabric.modmenu.gui.ConfigurationListWidget;
 import com.sigmundgranaas.forgero.fabric.modmenu.gui.OptionEntryFactory;
-
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.option.GameOptionsScreen;
@@ -16,9 +17,9 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.screen.ScreenTexts;
 import net.minecraft.text.Text;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.loader.api.FabricLoader;
 
 @Environment(EnvType.CLIENT)
 public class ForgeroConfigurationScreen extends GameOptionsScreen {
@@ -76,7 +77,7 @@ public class ForgeroConfigurationScreen extends GameOptionsScreen {
 		}
 
 		this.addDrawableChild(new ButtonWidget(this.width / 2 - 154, this.height - 28, 150, 20, Text.translatable("forgero.menu.options.reload_config"), button -> {
-			ForgeroConfigurationLoader.load();
+			ForgeroConfigurationLoader.load(FabricLoader.getInstance().getConfigDir());
 			RebuildConfigScreen();
 		}));
 		this.addDrawableChild(new ButtonWidget(this.width / 2 + 4, this.height - 28, 150, 20, ScreenTexts.DONE, button -> {

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/ForgeroInitializer.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/ForgeroInitializer.java
@@ -40,7 +40,7 @@ public class ForgeroInitializer implements ModInitializer {
 
 		Set<String> availableDependencies = FabricLoader.getInstance().getAllMods().stream().map(ModContainer::getMetadata).map(ModMetadata::getId).collect(Collectors.toSet());
 
-		var configuration = ForgeroConfigurationLoader.load();
+		var configuration = ForgeroConfigurationLoader.load(FabricLoader.getInstance().getConfigDir());
 
 		PipelineBuilder
 				.builder()

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/datareloader/DataPipeLineReloader.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/datareloader/DataPipeLineReloader.java
@@ -20,7 +20,7 @@ import net.fabricmc.loader.api.metadata.ModMetadata;
 public class DataPipeLineReloader implements SimpleSynchronousResourceReloadListener {
 	@Override
 	public void reload(ResourceManager manager) {
-		var config = ForgeroConfigurationLoader.load();
+		var config = ForgeroConfigurationLoader.load(FabricLoader.getInstance().getConfigDir());
 		Set<String> availableDependencies = FabricLoader.getInstance().getAllMods().stream().map(ModContainer::getMetadata).map(ModMetadata::getId).collect(Collectors.toSet());
 		PipelineBuilder.builder()
 				.register(() -> config)

--- a/fabric/forgero-fabric-core/src/test/java/com/sigmundgranaas/forgerofabric/nbt/v2/StateNbtConversionTest.java
+++ b/fabric/forgero-fabric-core/src/test/java/com/sigmundgranaas/forgerofabric/nbt/v2/StateNbtConversionTest.java
@@ -1,5 +1,8 @@
 package com.sigmundgranaas.forgerofabric.nbt.v2;
 
+import java.util.ArrayList;
+import java.util.Set;
+
 import com.sigmundgranaas.forgero.core.ForgeroStateRegistry;
 import com.sigmundgranaas.forgero.core.configuration.ForgeroConfigurationLoader;
 import com.sigmundgranaas.forgero.core.property.AttributeType;
@@ -17,16 +20,18 @@ import com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.CompositeEncoder;
 import com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.CompositeParser;
 import com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.CompoundEncoder;
 import com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.StateParser;
-import com.sigmundgranaas.forgerofabric.testutil.*;
-
-import net.minecraft.nbt.NbtCompound;
-
+import com.sigmundgranaas.forgerofabric.testutil.Materials;
+import com.sigmundgranaas.forgerofabric.testutil.ToolParts;
+import com.sigmundgranaas.forgerofabric.testutil.Tools;
+import com.sigmundgranaas.forgerofabric.testutil.Types;
+import com.sigmundgranaas.forgerofabric.testutil.Upgrades;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Set;
+import net.minecraft.nbt.NbtCompound;
+
+import net.fabricmc.loader.api.FabricLoader;
 
 public class StateNbtConversionTest {
 	private static final CompoundEncoder<State> encoder = new CompositeEncoder();
@@ -34,7 +39,7 @@ public class StateNbtConversionTest {
 
 	@BeforeEach
 	void genData() {
-		ForgeroConfigurationLoader.load();
+		ForgeroConfigurationLoader.load(FabricLoader.getInstance().getConfigDir());
 		PipelineBuilder
 				.builder()
 				.register(FabricPackFinder.supplier())

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/configuration/ForgeroConfigurationLoader.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/configuration/ForgeroConfigurationLoader.java
@@ -1,26 +1,35 @@
 package com.sigmundgranaas.forgero.core.configuration;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonReader;
 import com.sigmundgranaas.forgero.core.Forgero;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.text.MessageFormat;
-
 public class ForgeroConfigurationLoader {
 	public static final ForgeroConfiguration defaultConfiguration = new ForgeroConfiguration();
 
 	public static String configurationFileName = "forgero_settings.json";
-	public static String configurationFolderName = "config";
-	public static Path configurationFilePath = Path.of(MessageFormat.format("./{0}/{1}", configurationFolderName, configurationFileName));
+	public static Path configurationFolderPath;
+	public static Path configurationFilePath;
+	public static boolean havePathsBeenResolved = false;
 
 	public static ForgeroConfiguration configuration = defaultConfiguration;
 
-	public static ForgeroConfiguration load() {
+	public static ForgeroConfiguration load(Path configDir) {
+		configurationFolderPath = configDir;
+		configurationFilePath = configurationFolderPath.resolve(configurationFileName);
+		havePathsBeenResolved = true;
+
 		if (!Files.exists(configurationFilePath)) {
 			configuration = createConfigurationFile();
 			return configuration;
@@ -36,7 +45,10 @@ public class ForgeroConfigurationLoader {
 
 			return configuration;
 		} catch (IOException e) {
-			Forgero.LOGGER.warn("Unable to read Forgero configuration file, located at {}. Loading default configuration. Check if the formatting is correct. See stack trace below:", configurationFilePath);
+			Forgero.LOGGER.warn(
+					"Unable to read Forgero configuration file, located at {}. Loading default configuration. Check if the formatting is correct. See stack trace below:",
+					configurationFilePath
+			);
 			e.printStackTrace();
 
 			// Worst case scenario, return the default configuration
@@ -46,6 +58,11 @@ public class ForgeroConfigurationLoader {
 	}
 
 	public static void save() {
+		if (!havePathsBeenResolved) {
+			Forgero.LOGGER.warn("Unable to save Forgero configuration file, configuration file path hasn't been resolved yet. ForgeroConfigurationLoader#load should be called before ForgeroConfigurationLoader#save.");
+			return;
+		}
+
 		try (FileWriter writer = new FileWriter(configurationFilePath.toString())) {
 			var gson = createGson();
 			var json = gson.toJson(configuration);
@@ -56,15 +73,22 @@ public class ForgeroConfigurationLoader {
 		}
 	}
 
-	private static @NotNull
-	Gson createGson() {
+	private static @NotNull Gson createGson() {
 		GsonBuilder gsonBuilder = new GsonBuilder();
 		return gsonBuilder.setPrettyPrinting().create();
 	}
 
 	private static ForgeroConfiguration createConfigurationFile() {
-		if (!new File(configurationFolderName).exists()) {
-			Forgero.LOGGER.warn("Unable to create Forgero configuration file at {}. Configuration folder (/config) doesn't exist. Loading default configuration.", configurationFilePath);
+		if (!havePathsBeenResolved) {
+			Forgero.LOGGER.warn("Unable to create Forgero configuration file, configuration file path hasn't been resolved yet. ForgeroConfigurationLoader#load should be called before ForgeroConfigurationLoader#createConfigurationFile.");
+			return ForgeroConfigurationLoader.defaultConfiguration;
+		}
+
+		if (!configurationFolderPath.toFile().exists()) {
+			Forgero.LOGGER.warn(
+					"Unable to create Forgero configuration file at {}. Configuration folder (/config) doesn't exist. Loading default configuration.",
+					configurationFilePath
+			);
 
 			// Worst case scenario, return the default configuration
 			return ForgeroConfigurationLoader.defaultConfiguration;
@@ -79,7 +103,10 @@ public class ForgeroConfigurationLoader {
 
 			return defaultConfiguration;
 		} catch (IOException e) {
-			Forgero.LOGGER.warn("Unable to create Forgero configuration file at {}. Loading default configuration. See stack trace below:", configurationFilePath);
+			Forgero.LOGGER.warn(
+					"Unable to create Forgero configuration file at {}. Loading default configuration. See stack trace below:",
+					configurationFilePath
+			);
 			e.printStackTrace();
 
 			// Worst case scenario, return the default configuration


### PR DESCRIPTION
`config/` directory is no longer hardcoded to be relative to the process' working directory, but is now fetched via `FabricLoader.getInstance().getConfigDir()` wherever possible.

