### PR TITLE
Rewrote the logic for encoding and parsing upgrades and slots.

### DIFF
--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/CompositeEncoder.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/CompositeEncoder.java
@@ -1,5 +1,7 @@
 package com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2;
 
+import static com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.NbtConstants.*;
+
 import com.sigmundgranaas.forgero.core.condition.Conditional;
 import com.sigmundgranaas.forgero.core.condition.NamedCondition;
 import com.sigmundgranaas.forgero.core.soul.SoulContainer;
@@ -13,15 +15,16 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.nbt.NbtString;
 
-import static com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.NbtConstants.*;
-
 public class CompositeEncoder implements CompoundEncoder<State> {
 	private final IdentifiableEncoder identifiableEncoder;
+
+	private final SlotEncoder slotEncoder;
 	private final StateEncoder stateEncoder;
 
 	public CompositeEncoder() {
 		this.stateEncoder = new StateEncoder();
 		this.identifiableEncoder = new IdentifiableEncoder();
+		this.slotEncoder = new SlotEncoder(stateEncoder);
 	}
 
 	public static NbtList encodeConditions(Conditional<?> conditional) {
@@ -61,7 +64,11 @@ public class CompositeEncoder implements CompoundEncoder<State> {
 		}
 		if (element instanceof Upgradeable<?> upgradeable) {
 			var upgrades = new NbtList();
-			upgradeable.upgrades().stream().map(stateEncoder::encode).forEach(upgrades::add);
+			// Use the SlotEncoder to encode each upgrade slot
+			upgradeable.slots().forEach(upgrade -> {
+				NbtCompound upgradeCompound = slotEncoder.encode(upgrade);
+				upgrades.add(upgradeCompound);
+			});
 			compound.put(UPGRADES_IDENTIFIER, upgrades);
 		}
 		return compound;

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/CompositeParser.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/CompositeParser.java
@@ -1,17 +1,17 @@
 package com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2;
 
-import com.sigmundgranaas.forgero.core.registry.StateFinder;
-import com.sigmundgranaas.forgero.core.state.State;
-
-import net.minecraft.nbt.NbtCompound;
-import net.minecraft.nbt.NbtElement;
+import static com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.NbtConstants.CONDITIONS_IDENTIFIER;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.NbtConstants.CONDITIONS_IDENTIFIER;
+import com.sigmundgranaas.forgero.core.registry.StateFinder;
+import com.sigmundgranaas.forgero.core.state.State;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
 
 
 public class CompositeParser implements CompoundParser<State> {
@@ -37,7 +37,7 @@ public class CompositeParser implements CompoundParser<State> {
 		return new ConstructParser(supplier).parse(compound);
 	}
 
-	protected void parseParts(Consumer<State> partConsumer, NbtCompound compound) {
+	public void parseParts(Consumer<State> partConsumer, NbtCompound compound) {
 		if (compound.contains(NbtConstants.INGREDIENTS_IDENTIFIER)) {
 			parseEntries(compound.getList(NbtConstants.INGREDIENTS_IDENTIFIER, NbtElement.COMPOUND_TYPE)).forEach(partConsumer);
 		}
@@ -46,7 +46,7 @@ public class CompositeParser implements CompoundParser<State> {
 		}
 	}
 
-	protected void parseUpgrades(Consumer<State> partConsumer, NbtCompound compound) {
+	public void parseUpgrades(Consumer<State> partConsumer, NbtCompound compound) {
 		if (compound.contains(NbtConstants.UPGRADES_IDENTIFIER)) {
 			parseEntries(compound.getList(NbtConstants.UPGRADES_IDENTIFIER, NbtElement.COMPOUND_TYPE)).forEach(partConsumer);
 		}
@@ -55,7 +55,7 @@ public class CompositeParser implements CompoundParser<State> {
 		}
 	}
 
-	private List<State> parseEntries(List<NbtElement> elements) {
+	public List<State> parseEntries(List<NbtElement> elements) {
 		return elements
 				.stream()
 				.map(this::parseEntry)
@@ -63,7 +63,7 @@ public class CompositeParser implements CompoundParser<State> {
 				.toList();
 	}
 
-	private Optional<State> parseEntry(NbtElement element) {
+	public Optional<State> parseEntry(NbtElement element) {
 		if (element.getType() == NbtElement.STRING_TYPE) {
 			return supplier.find(element.asString());
 		} else if (element.getType() == NbtElement.COMPOUND_TYPE) {
@@ -76,7 +76,7 @@ public class CompositeParser implements CompoundParser<State> {
 		return Optional.empty();
 	}
 
-	private Optional<State> parseCompound(NbtCompound compound, Function<String, Optional<State>> supplier) {
+	public Optional<State> parseCompound(NbtCompound compound, Function<String, Optional<State>> supplier) {
 		if (compound.contains(NbtConstants.STATE_TYPE_IDENTIFIER)) {
 			if (compound.getString(NbtConstants.STATE_TYPE_IDENTIFIER).equals(NbtConstants.STATE_IDENTIFIER) && !compound.contains(CONDITIONS_IDENTIFIER)) {
 				return supplier.apply(compound.getString(NbtConstants.ID_IDENTIFIER));

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/ConstructParser.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/ConstructParser.java
@@ -25,8 +25,11 @@ public class ConstructParser extends CompositeParser {
 		if (compound.contains(NbtConstants.ID_IDENTIFIER)) {
 			var id = compound.getString(NbtConstants.ID_IDENTIFIER);
 			var stateOpt = supplier.find(id);
+
 			if (stateOpt.isPresent() && stateOpt.get() instanceof Construct construct) {
-				builder = Construct.builder(construct.getSlotContainer().copy());
+				var container = new SlotContainerParser(construct, new SlotParser(new StateParser(supplier)), new CompositeParser(supplier))
+						.parse(compound);
+				builder = Construct.builder(container.get());
 			} else if (ForgeroStateRegistry.CONTAINER_TO_STATE.containsKey(id)) {
 				return supplier.find(ForgeroStateRegistry.CONTAINER_TO_STATE.get(id));
 			} else {
@@ -48,8 +51,6 @@ public class ConstructParser extends CompositeParser {
 		}
 
 		parseParts(builder::addIngredient, compound);
-
-		parseUpgrades(builder::addUpgrade, compound);
 
 		return Optional.of(builder.build());
 	}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/NbtConstants.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/NbtConstants.java
@@ -1,37 +1,37 @@
 package com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2;
 
-public class NbtConstants {
-	public static String FORGERO_IDENTIFIER = "FORGERO";
+public final class NbtConstants {
+	public static final String KEY_CODEC_TYPE = "codecType";
+	public static final String KEY_INDEX = "index";
+	public static final String KEY_DESCRIPTION = "description";
 
+	public static final String KEY_TYPE = "description";
+	public static final String KEY_CATEGORIES = "categories";
+	public static final String KEY_UPGRADE = "upgrade";
+	public static final String VALUE_EMPTY_SLOT_TYPE = "forgero:empty_slot";
+	public static final String VALUE_FILLED_SLOT_TYPE = "forgero:filled_slot";
+	public static String FORGERO_IDENTIFIER = "FORGERO";
 	//Misc
 	public static String NAME_IDENTIFIER = "NAME";
 	public static String NAMESPACE_IDENTIFIER = "NAMESPACE";
-
 	public static String TYPE_IDENTIFIER = "TYPE";
 	public static String ID_IDENTIFIER = "ID";
-
 	//State
 	public static String STATE_IDENTIFIER = "STATE";
 	public static String STATE_TYPE_IDENTIFIER = "STATE_TYPE";
 	public static String DEFAULT_IDENTIFIER = "DEFAULT";
 	public static String COMPOSITE_IDENTIFIER = "COMPOSITE";
-
 	public static String LEVELED_IDENTIFIER = "LEVELED";
 	public static String STATIC_IDENTIFIER = "STATIC";
 	public static String INGREDIENTS_IDENTIFIER = "INGREDIENTS";
 	public static String UPGRADES_IDENTIFIER = "UPGRADES";
-
 	public static String LEVEL_IDENTIFIER = "LEVEL";
 	public static String XP_IDENTIFIER = "XP";
-
 	public static String SOUL_IDENTIFIER = "SOUL";
-
 	public static String CONDITIONS_IDENTIFIER = "CONDITIONS";
 	public static String COMPOSITE_TYPE = "COMPOSITE_TYPE";
 	public static String TOOL_IDENTIFIER = "TOOL";
-
 	public static String SCHEMATIC_PART_IDENTIFIER = "SCHEMATIC_PART";
-
 	public static String TRACKER_IDENTIFIER = "TRACKER";
 	public static String MOB_TRACKER_IDENTIFIER = "MOB_TRACKER";
 	public static String BLOCK_TRACKER_IDENTIFIER = "BLOCK_TRACKER";

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SchematicPartParser.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SchematicPartParser.java
@@ -48,9 +48,10 @@ public class SchematicPartParser extends CompositeParser {
 				var builder = optBuilder.get();
 				builder.id(id);
 				if (stateOpt.isPresent() && stateOpt.get() instanceof Composite upgradeable) {
-					builder.addSlotContainer(upgradeable.getSlotContainer().copy());
+					new SlotContainerParser(upgradeable, new SlotParser(new StateParser(supplier)), new CompositeParser(supplier))
+							.parse(compound)
+							.ifPresent(builder::addSlotContainer);
 				}
-				parseUpgrades(builder::addUpgrade, compound);
 				if (compound.contains(TYPE_IDENTIFIER)) {
 					builder.type(Type.of(compound.getString(TYPE_IDENTIFIER)));
 				}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotContainerParser.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotContainerParser.java
@@ -1,0 +1,146 @@
+package com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2;
+
+import static com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.NbtConstants.STATE_TYPE_IDENTIFIER;
+import static com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.NbtConstants.UPGRADES_IDENTIFIER;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import com.sigmundgranaas.forgero.core.state.Composite;
+import com.sigmundgranaas.forgero.core.state.Slot;
+import com.sigmundgranaas.forgero.core.state.State;
+import com.sigmundgranaas.forgero.core.state.upgrade.slot.SlotContainer;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
+
+
+/**
+ * Slot Container Parser: Responsible for parsing slot containers, including both legacy and new formats
+ *
+ * <p>This class is responsible for parsing the slot container from the given NBT compound. It considers
+ * both legacy formats (represented by strings or custom state objects) and new formats (represented by slots).
+ * Depending on the detection, the parser follows either the legacy path or the new format path.
+ *
+ * <p>Keys Used:
+ * <ul>
+ *     <li>"UPGRADES_IDENTIFIER": Identifier for the upgrades section in the compound.</li>
+ *     <li>"STATE_TYPE_IDENTIFIER": Identifier for the state type within the compound.</li>
+ * </ul>
+ *
+ * <p>Usage Example:
+ * <pre>
+ * {@code
+ * Composite defaultState = ...;
+ * SlotParser slotParser = ...;
+ * CompositeParser compositeParser = ...;
+ * SlotContainerParser parser = new SlotContainerParser(defaultState, slotParser, compositeParser);
+ * Optional<SlotContainer> slotContainer = parser.parse(compound);
+ * }
+ * </pre>
+ *
+ * @see Composite
+ * @see SlotParser
+ * @see CompositeParser
+ */
+public class SlotContainerParser implements CompoundParser<SlotContainer> {
+	private final Composite defaultState;
+	private final CompositeParser compositeParser;
+	private final SlotParser slotParser;
+
+	/**
+	 * Constructor to initialize SlotContainerParser with the required parsers
+	 *
+	 * @param defaultState    the default state of the composite
+	 * @param slotParser      the parser for individual slots
+	 * @param compositeParser the parser for composites
+	 */
+	public SlotContainerParser(Composite defaultState, SlotParser slotParser, CompositeParser compositeParser) {
+		this.defaultState = defaultState;
+		this.compositeParser = compositeParser;
+		this.slotParser = slotParser;
+	}
+
+	@Override
+	public Optional<SlotContainer> parse(NbtCompound compound) {
+		if (compound.contains(UPGRADES_IDENTIFIER) && containsAnyLegacy(compound)) {
+			return parseLegacy(compound);
+		} else {
+			return parseSlots(compound.getList(NbtConstants.UPGRADES_IDENTIFIER, NbtElement.COMPOUND_TYPE));
+		}
+	}
+
+	/**
+	 * Checks if the compound contains any legacy format
+	 *
+	 * @param compound the NBT compound to check
+	 * @return true if legacy format is detected, false otherwise
+	 */
+	private boolean containsAnyLegacy(@Nullable NbtCompound compound) {
+		if (compound == null) {
+			return false;
+		}
+		boolean isLegacy = false;
+		if (compound.contains(NbtConstants.UPGRADES_IDENTIFIER)) {
+			isLegacy = compound.getList(NbtConstants.UPGRADES_IDENTIFIER, NbtElement.COMPOUND_TYPE).stream().anyMatch(this::isLegacy);
+		}
+		if (compound.contains(NbtConstants.UPGRADES_IDENTIFIER)) {
+			isLegacy = compound.getList(NbtConstants.UPGRADES_IDENTIFIER, NbtElement.STRING_TYPE).stream().anyMatch(this::isLegacy);
+		}
+		return isLegacy;
+	}
+
+	/**
+	 * Checks if the given NbtElement is in legacy format
+	 *
+	 * @param element the NBT element to check
+	 * @return true if the element is in legacy format, false otherwise
+	 */
+	private boolean isLegacy(@Nullable NbtElement element) {
+		if (element == null) {
+			return true;
+		}
+		if (element.getType() == NbtElement.STRING_TYPE) {
+			return true;
+		} else
+			return element.getType() == NbtElement.COMPOUND_TYPE && ((NbtCompound) element).contains(STATE_TYPE_IDENTIFIER);
+	}
+
+
+	/**
+	 * Parses the legacy format of upgrades
+	 *
+	 * @param upgrades the NBT compound containing upgrades
+	 * @return the parsed SlotContainer wrapped in an Optional
+	 */
+	public Optional<SlotContainer> parseLegacy(NbtCompound upgrades) {
+		ArrayList<State> states = new ArrayList<>();
+		var slotContainer = defaultState.getSlotContainer().copy();
+		compositeParser.parseUpgrades(states::add, upgrades);
+		states.forEach(slotContainer::set);
+		return Optional.of(slotContainer);
+	}
+
+	/**
+	 * Parses the new format of slots
+	 *
+	 * @param upgrades the NbtList containing the slots
+	 * @return the parsed SlotContainer wrapped in an Optional
+	 */
+	public Optional<SlotContainer> parseSlots(NbtList upgrades) {
+		List<Slot> slots = upgrades.stream()
+				.filter(NbtCompound.class::isInstance)
+				.map(NbtCompound.class::cast)
+				.map(slotParser::parse)
+				.flatMap(Optional::stream)
+				.sorted(Comparator.comparingInt(Slot::index).reversed())
+				.collect(Collectors.toList());
+		return Optional.of(new SlotContainer(slots));
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotContainerParser.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotContainerParser.java
@@ -88,10 +88,8 @@ public class SlotContainerParser implements CompoundParser<SlotContainer> {
 		}
 		boolean isLegacy = false;
 		if (compound.contains(NbtConstants.UPGRADES_IDENTIFIER)) {
-			isLegacy = compound.getList(NbtConstants.UPGRADES_IDENTIFIER, NbtElement.COMPOUND_TYPE).stream().anyMatch(this::isLegacy);
-		}
-		if (compound.contains(NbtConstants.UPGRADES_IDENTIFIER)) {
-			isLegacy = compound.getList(NbtConstants.UPGRADES_IDENTIFIER, NbtElement.STRING_TYPE).stream().anyMatch(this::isLegacy);
+			isLegacy = compound.getList(NbtConstants.UPGRADES_IDENTIFIER, NbtElement.COMPOUND_TYPE).stream().anyMatch(this::isLegacy)
+					|| compound.getList(NbtConstants.UPGRADES_IDENTIFIER, NbtElement.STRING_TYPE).stream().anyMatch(this::isLegacy);
 		}
 		return isLegacy;
 	}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotContainerParser.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotContainerParser.java
@@ -137,7 +137,7 @@ public class SlotContainerParser implements CompoundParser<SlotContainer> {
 				.map(NbtCompound.class::cast)
 				.map(slotParser::parse)
 				.flatMap(Optional::stream)
-				.sorted(Comparator.comparingInt(Slot::index).reversed())
+				.sorted(Comparator.comparingInt(Slot::index))
 				.collect(Collectors.toList());
 		return Optional.of(new SlotContainer(slots));
 	}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotEncoder.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotEncoder.java
@@ -1,0 +1,122 @@
+package com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2;
+
+import static com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.NbtConstants.*;
+
+import java.util.Set;
+
+import com.sigmundgranaas.forgero.core.property.attribute.Category;
+import com.sigmundgranaas.forgero.core.state.Slot;
+import com.sigmundgranaas.forgero.core.state.upgrade.slot.AbstractTypedSlot;
+import com.sigmundgranaas.forgero.core.state.upgrade.slot.EmptySlot;
+import com.sigmundgranaas.forgero.core.state.upgrade.slot.FilledSlot;
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtList;
+import net.minecraft.nbt.NbtString;
+
+/**
+ * Encoder class to handle the encoding of Slot objects into Minecraft's NBT (Named Binary Tag) format.
+ * It supports the encoding of both {@link EmptySlot} and {@link FilledSlot} objects and utilizes the {@link StateEncoder}
+ * for handling specific encodings within the objects.
+ *
+ * <p>This class implements the {@link CompoundEncoder} interface, providing a standardized way to translate
+ * Slot objects into their NBT format. This encoding is essential for saving and transmitting these objects
+ * within the Minecraft environment.
+ *
+ * <p>The encoded NBT format includes various keys to represent the object's properties:
+ * <ul>
+ *     <li>"codecType": Represents the type of slot, e.g., "forgero:empty_slot" or "forgero:filled_slot"</li>
+ *     <li>"index": The index of the slot</li>
+ *     <li>"description": The description of the slot</li>
+ *     <li>"categories": The set of categories associated with the slot, encoded as a list of strings</li>
+ *     <li>"upgrade": Encoded state object present in the filled slot</li>
+ * </ul>
+ *
+ * <p>Usage Example:
+ * <pre>
+ * {@code
+ * Slot slot = ...;
+ * StateEncoder stateEncoder = ...;
+ * SlotEncoder encoder = new SlotEncoder(stateEncoder);
+ * NbtCompound compound = encoder.encode(slot);
+ * }
+ * </pre>
+ *
+ * @see CompoundEncoder
+ * @see EmptySlot
+ * @see FilledSlot
+ * @see StateEncoder
+ */
+public class SlotEncoder implements CompoundEncoder<Slot> {
+
+
+	public static final String VALUE_EMPTY_SLOT_TYPE = "forgero:empty_slot";
+	public static final String VALUE_FILLED_SLOT_TYPE = "forgero:filled_slot";
+
+	private final StateEncoder stateEncoder;
+
+	/**
+	 * Constructor to initialize SlotEncoder with the state encoder.
+	 *
+	 * @param stateEncoder the encoder for states
+	 */
+	public SlotEncoder(@NotNull StateEncoder stateEncoder) {
+		this.stateEncoder = stateEncoder;
+	}
+
+	/**
+	 * Encodes the given Slot object into an {@link NbtCompound}.
+	 *
+	 * <p>This method identifies the specific type of Slot (either EmptySlot or FilledSlot) and
+	 * encodes it accordingly. In the case of a FilledSlot, it also leverages the {@link StateEncoder}
+	 * to encode the 'upgrade' field.
+	 *
+	 * @param element The Slot object to be encoded.
+	 * @return The encoded NbtCompound representing the Slot.
+	 */
+	@Override
+	@NotNull
+	public NbtCompound encode(@NotNull Slot element) {
+		if (element instanceof EmptySlot emptySlot) {
+			return encodeEmptySlot(emptySlot);
+		} else if (element instanceof FilledSlot filledSlot) {
+			return encodeFilledSlot(filledSlot);
+		}
+		return stateEncoder.encode(element);
+	}
+
+	@NotNull
+	private NbtCompound encodeEmptySlot(@NotNull EmptySlot emptySlot) {
+		NbtCompound compound = encodeAbstractSlot(emptySlot);
+		compound.putString(KEY_CODEC_TYPE, VALUE_EMPTY_SLOT_TYPE);
+		return compound;
+	}
+
+	@NotNull
+	private NbtCompound encodeFilledSlot(@NotNull FilledSlot filledSlot) {
+		NbtCompound compound = encodeAbstractSlot(filledSlot);
+		compound.putString(KEY_CODEC_TYPE, VALUE_FILLED_SLOT_TYPE);
+		compound.put(KEY_UPGRADE, stateEncoder.encode(filledSlot.content()));
+		return compound;
+	}
+
+	@NotNull
+	private NbtCompound encodeAbstractSlot(@NotNull AbstractTypedSlot typedSlot) {
+		NbtCompound compound = new NbtCompound();
+		compound.putInt(KEY_INDEX, typedSlot.index());
+		compound.putString(KEY_DESCRIPTION, typedSlot.description());
+		compound.put(KEY_CATEGORIES, encodeCategories(typedSlot.category()));
+		compound.putString(KEY_TYPE, typedSlot.type().typeName());
+		return compound;
+	}
+
+	@NotNull
+	private NbtList encodeCategories(@NotNull Set<Category> categories) {
+		NbtList list = new NbtList();
+		for (Category category : categories) {
+			list.add(NbtString.of(category.toString()));
+		}
+		return list;
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotParser.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/SlotParser.java
@@ -1,0 +1,93 @@
+package com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2;
+
+import static com.sigmundgranaas.forgero.minecraft.common.item.nbt.v2.NbtConstants.*;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import com.sigmundgranaas.forgero.core.property.attribute.Category;
+import com.sigmundgranaas.forgero.core.state.Slot;
+import com.sigmundgranaas.forgero.core.state.upgrade.slot.AbstractTypedSlot;
+import com.sigmundgranaas.forgero.core.state.upgrade.slot.EmptySlot;
+import com.sigmundgranaas.forgero.core.state.upgrade.slot.FilledSlot;
+import com.sigmundgranaas.forgero.core.type.Type;
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
+
+/**
+ * The {@code SlotParser} class is responsible for parsing {@link Slot} objects
+ * from the given NbtCompound format. It forms part of the system that handles
+ * the serialization and deserialization of slots in Minecraft's NBT (Named Binary Tag) format.
+ *
+ * <p>This class adheres to the {@link CompoundParser} interface, making it possible
+ * to parse the specific NbtCompound into a Slot object that can represent either an
+ * empty or filled slot.
+ *
+ * <p>For detailed information on the specific NBT structure being parsed,
+ * refer to the related classes {@link EmptySlot}, {@link FilledSlot}, and
+ * {@link AbstractTypedSlot}.
+ *
+ * <p>Usage Example:
+ * <pre>
+ * {@code
+ * NbtCompound compound = ...;
+ * SlotParser parser = new SlotParser();
+ * Optional<Slot> slot = parser.parse(compound);
+ * }
+ * </pre>
+ *
+ * @see CompoundParser
+ * @see EmptySlot
+ * @see FilledSlot
+ * @see AbstractTypedSlot
+ */
+public class SlotParser implements CompoundParser<Slot> {
+
+	private final StateParser stateParser;
+
+	public SlotParser(StateParser stateParser) {
+		this.stateParser = stateParser;
+	}
+
+	/**
+	 * Parses the given {@link NbtCompound} to an Optional {@link Slot} object.
+	 *
+	 * <p>This method will parse the given NbtCompound, identifying whether it represents
+	 * an empty or filled slot, and will create the corresponding Slot object accordingly.
+	 * If the NbtCompound does not contain the required information to form a Slot object,
+	 * an empty Optional is returned.
+	 *
+	 * @param compound The NbtCompound to parse.
+	 * @return An Optional containing the parsed Slot object if successful; otherwise, an empty Optional.
+	 */
+	@Override
+	public Optional<Slot> parse(@NotNull NbtCompound compound) {
+		if (!compound.contains(KEY_CODEC_TYPE)) {
+			return Optional.empty();
+		}
+
+		int index = compound.getInt(KEY_INDEX);
+		String description = compound.getString(KEY_DESCRIPTION);
+		Set<Category> categories = parseCategories(compound.getList(KEY_CATEGORIES, NbtElement.STRING_TYPE));
+		Type type = Type.of(compound.getString(KEY_TYPE));
+
+		return switch (compound.getString(KEY_CODEC_TYPE)) {
+			case VALUE_EMPTY_SLOT_TYPE -> Optional.of(new EmptySlot(index, type, description, categories));
+			case VALUE_FILLED_SLOT_TYPE -> stateParser.parse(compound.getCompound(KEY_UPGRADE))
+					.map(upgrade -> new FilledSlot(index, type, upgrade, description, categories));
+			default -> Optional.empty();
+		};
+	}
+
+	private Set<Category> parseCategories(NbtList categoryList) {
+		Set<Category> categories = new HashSet<>();
+		for (int i = 0; i < categoryList.size(); i++) {
+			categories.add(Category.valueOf(categoryList.getString(i)));
+		}
+		return categories;
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/ToolParser.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/nbt/v2/ToolParser.java
@@ -36,9 +36,11 @@ public class ToolParser extends CompositeParser {
 				var builder = optBuilder.get();
 				builder.id(id);
 				if (stateOpt.isPresent() && stateOpt.get() instanceof Composite upgradeable) {
-					builder.addSlotContainer(upgradeable.getSlotContainer().copy());
+					new SlotContainerParser(upgradeable, new SlotParser(new StateParser(supplier)), new CompositeParser(supplier))
+							.parse(compound)
+							.ifPresent(builder::addSlotContainer);
 				}
-				parseUpgrades(builder::addUpgrade, compound);
+
 				if (compound.contains(TYPE_IDENTIFIER)) {
 					builder.type(Type.of(compound.getString(TYPE_IDENTIFIER)));
 				}


### PR DESCRIPTION
Slots will now be serialized even if they are empty.
Old encoded formats should work, and should be encoded to new format.

This change is not backwards compatible

Closes #667 