### PR TITLE
Support any tag in packs

### DIFF
--- a/content/forgero-compat/src/main/resources/data/forgero/packs/common/material/bronze.json
+++ b/content/forgero-compat/src/main/resources/data/forgero/packs/common/material/bronze.json
@@ -1,9 +1,14 @@
 {
   "type": "METAL",
   "name": "bronze",
+  "dependencies": {
+    "any": [
+      "mythicmetals"
+    ]
+  },
   "container": {
     "type": "HOST",
-    "id": "mythicmetals:bronze_ingot"
+    "tag": "c:bronze_ingot"
   },
   "palette": {
     "name": "bronze"

--- a/content/forgero-compat/src/main/resources/data/forgero/packs/common/material/silver.json
+++ b/content/forgero-compat/src/main/resources/data/forgero/packs/common/material/silver.json
@@ -1,13 +1,18 @@
 {
   "type": "METAL",
   "parent": "metal",
-  "name": "steel",
+  "name": "silver",
+  "dependencies": {
+    "any": [
+      "mythicmetals"
+    ]
+  },
   "container": {
     "type": "HOST",
-    "id": "mythicmetals:steel_ingot"
+    "tag": "c:silver_ingot"
   },
   "palette": {
-    "name": "steel"
+    "name": "silver"
   },
   "properties": {
     "attributes": [
@@ -16,58 +21,58 @@
         "type": "RARITY",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 38
+        "value": 57
       },
       {
         "id": "metal-mining_level-composite",
         "type": "MINING_LEVEL",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 2.0
+        "value": 3
       },
       {
         "id": "metal-mining_speed-composite",
         "type": "MINING_SPEED",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 6.5
+        "value": 7
       },
       {
         "id": "metal-durability-composite",
         "type": "DURABILITY",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 600.0
+        "value": 658.0
       },
       {
         "id": "metal-attack_damage-composite",
         "type": "ATTACK_DAMAGE",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 1.9
+        "value": 2.7
       },
       {
         "id": "metal-armor-composite",
         "type": "ARMOR",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 4
+        "value": 3
       },
       {
         "id": "metal-weight-composite",
         "type": "WEIGHT",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 37
+        "value": 45
       },
       {
         "id": "metal-rarity-upgrade",
         "context": "UPGRADE",
         "type": "RARITY",
-        "context": "BASE",
+        "order": "BASE",
         "operation": "ADDITION",
         "category": "ALL",
-        "value": 17
+        "value": 25
       }
     ]
   }

--- a/content/forgero-compat/src/main/resources/data/forgero/packs/common/material/steel.json
+++ b/content/forgero-compat/src/main/resources/data/forgero/packs/common/material/steel.json
@@ -1,13 +1,18 @@
 {
   "type": "METAL",
   "parent": "metal",
-  "name": "silver",
+  "name": "steel",
+  "dependencies": {
+    "any": [
+      "mythicmetals"
+    ]
+  },
   "container": {
     "type": "HOST",
-    "id": "mythicmetals:silver_ingot"
+    "tag": "c:steel_ingot"
   },
   "palette": {
-    "name": "silver"
+    "name": "steel"
   },
   "properties": {
     "attributes": [
@@ -16,58 +21,58 @@
         "type": "RARITY",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 57
+        "value": 38
       },
       {
         "id": "metal-mining_level-composite",
         "type": "MINING_LEVEL",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 3
+        "value": 2.0
       },
       {
         "id": "metal-mining_speed-composite",
         "type": "MINING_SPEED",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 7
+        "value": 6.5
       },
       {
         "id": "metal-durability-composite",
         "type": "DURABILITY",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 658.0
+        "value": 600.0
       },
       {
         "id": "metal-attack_damage-composite",
         "type": "ATTACK_DAMAGE",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 2.7
+        "value": 1.9
       },
       {
         "id": "metal-armor-composite",
         "type": "ARMOR",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 3
+        "value": 4
       },
       {
         "id": "metal-weight-composite",
         "type": "WEIGHT",
         "context": "COMPOSITE",
         "operation": "ADDITION",
-        "value": 45
+        "value": 37
       },
       {
         "id": "metal-rarity-upgrade",
         "context": "UPGRADE",
         "type": "RARITY",
-        "order": "BASE",
+        "context": "BASE",
         "operation": "ADDITION",
         "category": "ALL",
-        "value": 25
+        "value": 17
       }
     ]
   }

--- a/content/forgero-compat/src/main/resources/data/forgero/packs/common/package.json
+++ b/content/forgero-compat/src/main/resources/data/forgero/packs/common/package.json
@@ -1,10 +1,15 @@
 {
-  "name": "common",
+  "name": "compat_common",
   "resource_type": "PACKAGE",
   "priority": 4,
   "namespace": "forgero",
-  "dependencies": [
-    "minecraft",
-    "forgero"
-  ]
+  "dependencies": {
+    "all": [
+      "minecraft",
+      "forgero"
+    ],
+    "any": [
+      "mythicmetals"
+    ]
+  }
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/ForgeroCompatInitializer.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/ForgeroCompatInitializer.java
@@ -3,6 +3,7 @@ package com.sigmundgranaas.forgero.fabric;
 import java.util.function.Supplier;
 
 import com.sigmundgranaas.forgero.fabric.api.entrypoint.ForgeroInitializedEntryPoint;
+import com.sigmundgranaas.forgero.fabric.mythicmetals.MythicMetalsCommons;
 import com.sigmundgranaas.forgero.fabric.patchouli.BookDropOnAdvancement;
 import com.sigmundgranaas.forgero.fabric.patchouli.GuideBookGenerator;
 import com.sigmundgranaas.forgero.fabric.toolstats.ToolStatTagGenerator;
@@ -15,9 +16,12 @@ public class ForgeroCompatInitializer implements ForgeroInitializedEntryPoint {
 	public static final Supplier<Boolean> patchouli;
 	public static final Supplier<Boolean> modmenu;
 	public static final Supplier<Boolean> bettercombat;
+	public static final Supplier<Boolean> mythicmetals;
+
 
 	static {
 		toolstats = () -> isModLoaded("toolstats");
+		mythicmetals = () -> isModLoaded("mythicmetals");
 		patchouli = () -> isModLoaded("patchouli");
 		modmenu = () -> isModLoaded("modmenu");
 		bettercombat = () -> isModLoaded("bettercombat");
@@ -36,6 +40,10 @@ public class ForgeroCompatInitializer implements ForgeroInitializedEntryPoint {
 		if (patchouli.get()) {
 			BookDropOnAdvancement.registerBookDrop();
 			GuideBookGenerator.registerGuideBookRecipes();
+		}
+
+		if (mythicmetals.get()) {
+			MythicMetalsCommons.generateTags();
 		}
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/mythicmetals/MythicMetalsCommons.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/mythicmetals/MythicMetalsCommons.java
@@ -1,0 +1,15 @@
+package com.sigmundgranaas.forgero.fabric.mythicmetals;
+
+import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+
+import net.devtech.arrp.json.tags.JTag;
+
+import net.minecraft.util.Identifier;
+
+public class MythicMetalsCommons {
+	public static void generateTags() {
+		RESOURCE_PACK.addTag(new Identifier("c", "items/silver_ingot"), JTag.tag().add(new Identifier("mythicmetals:silver_ingot")));
+		RESOURCE_PACK.addTag(new Identifier("c", "items/bronze_ingot"), JTag.tag().add(new Identifier("mythicmetals:bronze_ingot")));
+		RESOURCE_PACK.addTag(new Identifier("c", "items/steel_ingot"), JTag.tag().add(new Identifier("mythicmetals:steel_ingot")));
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/DataPackage.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/DataPackage.java
@@ -1,16 +1,16 @@
 package com.sigmundgranaas.forgero.core.resource.data.v2;
 
+import java.util.List;
+
 import com.sigmundgranaas.forgero.core.resource.data.v2.data.DataResource;
+import com.sigmundgranaas.forgero.core.resource.data.v2.data.DependencyData;
 import com.sigmundgranaas.forgero.core.resource.data.v2.packages.DefaultPackage;
 import com.sigmundgranaas.forgero.core.state.Identifiable;
 import com.sigmundgranaas.forgero.core.util.Identifiers;
 
-import java.util.Collections;
-import java.util.List;
-
 public interface DataPackage extends Identifiable {
 	static DataPackage of(List<DataResource> data) {
-		return new DefaultPackage(Collections.emptyList(), 6, () -> data, Identifiers.EMPTY_IDENTIFIER, Identifiers.EMPTY_IDENTIFIER);
+		return new DefaultPackage(DependencyData.empty(), 6, () -> data, Identifiers.EMPTY_IDENTIFIER, Identifiers.EMPTY_IDENTIFIER);
 	}
 
 	static DataPackage of(DataResource data) {
@@ -19,7 +19,7 @@ public interface DataPackage extends Identifiable {
 
 	int priority();
 
-	List<String> dependencies();
+	DependencyData dependencies();
 
 	List<DataResource> loadData();
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DataResource.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DataResource.java
@@ -53,7 +53,7 @@ public class DataResource implements Identifiable {
 
 	@Nullable
 	@SerializedName(value = "dependencies", alternate = "dependency")
-	private List<String> dependencies;
+	private DependencyData dependencies;
 
 	@Nullable
 	private ConstructData construct;
@@ -137,11 +137,11 @@ public class DataResource implements Identifiable {
 	}
 
 	@NotNull
-	public ImmutableList<String> dependencies() {
+	public DependencyData dependencies() {
 		if (dependencies == null) {
-			return ImmutableList.<String>builder().build();
+			return DependencyData.empty();
 		}
-		return ImmutableList.<String>builder().addAll(dependencies).build();
+		return dependencies;
 	}
 
 	@NotNull

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DependencyData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DependencyData.java
@@ -21,7 +21,7 @@ import lombok.Builder;
 public class DependencyData {
 
 	@Builder.Default
-	@SerializedName(value = "dependencies", alternate = "dependency")
+	@SerializedName(value = "dependencies", alternate = "all")
 	private Set<String> dependencies = Collections.emptySet();
 
 	@Builder.Default

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DependencyData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DependencyData.java
@@ -1,0 +1,82 @@
+package com.sigmundgranaas.forgero.core.resource.data.v2.data;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public class DependencyData {
+
+	@Builder.Default
+	@SerializedName(value = "dependencies", alternate = "dependency")
+	private Set<String> dependencies = Collections.emptySet();
+
+	@Builder.Default
+	@SerializedName(value = "any", alternate = "any_of")
+	private Set<String> any_of = Collections.emptySet();
+
+	@Builder.Default
+	@SerializedName(value = "none", alternate = "none_of")
+	private Set<String> none_of = Collections.emptySet();
+
+	public static DependencyData of(List<String> dependencies) {
+		return DependencyData.builder().dependencies(Set.copyOf(dependencies)).build();
+	}
+
+	public static DependencyData empty() {
+		return DependencyData.builder().build();
+	}
+
+	public Set<String> getDependencies() {
+		return safe(dependencies);
+	}
+
+	private Set<String> safe(@Nullable Set<String> elements) {
+		return Objects.requireNonNullElseGet(elements, Collections::emptySet);
+	}
+
+
+	public Set<String> getAny_of() {
+		return safe(any_of);
+	}
+
+	public Set<String> getNone_of() {
+		return safe(none_of);
+	}
+
+	public boolean isEmpty() {
+		return getDependencies().isEmpty() && getAny_of().isEmpty() && getNone_of().isEmpty();
+	}
+
+	public static class DependencyDataDeserializer implements JsonDeserializer<DependencyData> {
+
+		@Override
+		public DependencyData deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+			if (json.isJsonArray()) {
+				// Handle as array
+				List<String> dependenciesList = new ArrayList<>();
+				for (JsonElement element : json.getAsJsonArray()) {
+					dependenciesList.add(element.getAsString());
+				}
+				return DependencyData.of(dependenciesList);
+			} else if (json.isJsonObject()) {
+				// Handle as object
+				return new Gson().fromJson(json, DependencyData.class);
+			}
+			throw new JsonParseException("Unsupported type for dependencies field");
+		}
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/loading/FileResourceProvider.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/loading/FileResourceProvider.java
@@ -18,6 +18,7 @@ import com.sigmundgranaas.forgero.core.resource.data.deserializer.ContextDeseria
 import com.sigmundgranaas.forgero.core.resource.data.v2.DataResourceProvider;
 import com.sigmundgranaas.forgero.core.resource.data.v2.data.ContextData;
 import com.sigmundgranaas.forgero.core.resource.data.v2.data.DataResource;
+import com.sigmundgranaas.forgero.core.resource.data.v2.data.DependencyData;
 import com.sigmundgranaas.forgero.core.util.loader.ClassLoader;
 import com.sigmundgranaas.forgero.core.util.loader.InputStreamLoader;
 
@@ -46,6 +47,7 @@ public class FileResourceProvider implements DataResourceProvider {
 				JsonReader reader = new JsonReader(new InputStreamReader(stream));
 				var context = createContextFromPath(path);
 				GsonBuilder builder = new GsonBuilder();
+				builder.registerTypeAdapter(DependencyData.class, new DependencyData.DependencyDataDeserializer());
 				builder.registerTypeAdapter(new TypeToken<List<PropertyPojo.Attribute>>() {
 				}.getType(), new AttributeGroupDeserializer());
 				builder.registerTypeAdapter(new TypeToken<Context>() {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/packages/DefaultPackage.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/packages/DefaultPackage.java
@@ -1,12 +1,13 @@
 package com.sigmundgranaas.forgero.core.resource.data.v2.packages;
 
-import com.sigmundgranaas.forgero.core.resource.data.v2.DataPackage;
-import com.sigmundgranaas.forgero.core.resource.data.v2.data.DataResource;
-
 import java.util.List;
 import java.util.function.Supplier;
 
-public record DefaultPackage(List<String> dependencies, int priority,
+import com.sigmundgranaas.forgero.core.resource.data.v2.DataPackage;
+import com.sigmundgranaas.forgero.core.resource.data.v2.data.DataResource;
+import com.sigmundgranaas.forgero.core.resource.data.v2.data.DependencyData;
+
+public record DefaultPackage(DependencyData dependencies, int priority,
                              Supplier<List<DataResource>> data,
                              String nameSpace, String name) implements DataPackage {
 	@Override

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/packages/FilePackageLoader.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/packages/FilePackageLoader.java
@@ -1,19 +1,20 @@
 package com.sigmundgranaas.forgero.core.resource.data.v2.packages;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import com.sigmundgranaas.forgero.core.resource.data.ResourceLoader;
 import com.sigmundgranaas.forgero.core.resource.data.v2.DataPackage;
 import com.sigmundgranaas.forgero.core.resource.data.v2.ResourceLocator;
 import com.sigmundgranaas.forgero.core.resource.data.v2.data.DataResource;
+import com.sigmundgranaas.forgero.core.resource.data.v2.data.DependencyData;
 import com.sigmundgranaas.forgero.core.resource.data.v2.loading.DefaultMapper;
 import com.sigmundgranaas.forgero.core.resource.data.v2.loading.FileResourceLoader;
 import com.sigmundgranaas.forgero.core.resource.data.v2.loading.JsonContentFilter;
 import com.sigmundgranaas.forgero.core.resource.data.v2.loading.PathWalker;
 import com.sigmundgranaas.forgero.core.util.Identifiers;
 import com.sigmundgranaas.forgero.core.util.loader.PathFinder;
-
-import java.util.List;
-import java.util.function.Supplier;
 
 public class FilePackageLoader implements Supplier<DataPackage> {
 	private final ResourceLoader loader;
@@ -50,8 +51,8 @@ public class FilePackageLoader implements Supplier<DataPackage> {
 
 	@Override
 	public DataPackage get() {
-		var packageInfo = loader.loadResource(folderPath + "/package.json");
-		var dependencies = packageInfo.map(DataResource::dependencies).orElse(ImmutableList.<String>builder().build());
+		Optional<DataResource> packageInfo = loader.loadResource(folderPath + "/package.json");
+		var dependencies = packageInfo.map(DataResource::dependencies).orElse(DependencyData.empty());
 		var priority = packageInfo.map(DataResource::priority).orElse(5);
 		var name = packageInfo.map(DataResource::name).orElse(Identifiers.EMPTY_IDENTIFIER);
 		var nameSpace = packageInfo.map(DataResource::nameSpace).orElse(Identifiers.EMPTY_IDENTIFIER);


### PR DESCRIPTION
Extends the dependencies syntax in resource and package files to make it possible to specify "all", "any" and "none" 