### PR TITLE
[Feature]: Added a NameVisitor to parse and inject custom names

### DIFF
--- a/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/knife_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/sword-additions/schematic/knife_blade.json
@@ -99,6 +99,10 @@
       "value": 1,
       "context": "LOCAL"
     },
+    "name_replacement": {
+      "from": "sword",
+      "to": "knife"
+    },
     "better_compat_attribute_container": "bettercombat:dagger"
   }
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/customdata/CustomNameVisitor.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/customdata/CustomNameVisitor.java
@@ -1,0 +1,80 @@
+package com.sigmundgranaas.forgero.minecraft.common.customdata;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.sigmundgranaas.forgero.core.customdata.ClassBasedVisitor;
+import com.sigmundgranaas.forgero.core.customdata.DataContainer;
+import com.sigmundgranaas.forgero.core.state.State;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+
+/**
+ * A visitor for {@link NameReplacementData}.
+ * <p>
+ * This class is designed to extract {@link NameReplacementData} from a {@link DataContainer}, which indicates parts of a name
+ * to be replaced for dynamic Forgero tools and weapons.
+ * The name replacements are applied to a string (e.g., name of an {@link State}) using {@link NameReplacementData#replace(String)}.
+ * Example:
+ * <p>
+ * Given the following custom data:
+ *
+ * <pre>
+ * "custom_data": {
+ *     "name_replacement": {
+ *       "from": "sword",
+ *       "to": "knife"
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * An item with the name "cobblestone-sword" will be transformed into "cobblestone-knife".
+ */
+public class CustomNameVisitor extends ClassBasedVisitor<CustomNameVisitor.NameReplacementData> {
+	public static final String KEY = "name_replacement";
+
+	private CustomNameVisitor() {
+		super(NameReplacementData.class, KEY);
+	}
+
+	/**
+	 * Extracts the first instance of {@link NameReplacementData} from the provided {@link DataContainer}.
+	 *
+	 * @param dataContainer The container possibly containing name replacement data.
+	 * @return The first name replacement data, if present.
+	 */
+	public static Optional<NameReplacementData> of(DataContainer dataContainer) {
+		return dataContainer.accept(new CustomNameVisitor());
+	}
+
+	/**
+	 * Extracts all instances of {@link NameReplacementData} from the provided {@link DataContainer}.
+	 *
+	 * @param dataContainer The container possibly containing multiple name replacement data.
+	 * @return All name replacements found, if any.
+	 */
+	public static List<NameReplacementData> ofAll(DataContainer dataContainer) {
+		return new CustomNameVisitor().visitMultiple(dataContainer);
+	}
+
+	/**
+	 * A data structure for storing name replacement information.
+	 */
+	@Data
+	@Accessors(fluent = true)
+	public static class NameReplacementData {
+		private String from;
+		private String to;
+
+		/**
+		 * Replaces occurrences of the "from" string with the "to" string in the provided name.
+		 *
+		 * @param name The original name/string where replacements should be performed.
+		 * @return The modified name with replacements.
+		 */
+		public String replace(String name) {
+			return name.replace(from, to);
+		}
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicAxeItem.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicAxeItem.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.state.StateProvider;
+import com.sigmundgranaas.forgero.minecraft.common.customdata.CustomNameVisitor;
 import com.sigmundgranaas.forgero.minecraft.common.item.ToolStateItem;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.StateWriter;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.Writer;
@@ -45,7 +46,11 @@ public class DynamicAxeItem extends AxeItem implements ToolStateItem {
 
 	@Override
 	public Text getName(ItemStack stack) {
-		return getName();
+		var state = dynamicState(stack);
+		return CustomNameVisitor.of(state.customData())
+				.map(replacer -> replacer.replace(state.name()))
+				.map(Writer::nameToTranslatableText)
+				.orElseGet(this::getName);
 	}
 
 

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicHoeItem.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicHoeItem.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.state.StateProvider;
+import com.sigmundgranaas.forgero.minecraft.common.customdata.CustomNameVisitor;
 import com.sigmundgranaas.forgero.minecraft.common.item.ToolStateItem;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.StateWriter;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.Writer;
@@ -45,7 +46,11 @@ public class DynamicHoeItem extends HoeItem implements ToolStateItem {
 
 	@Override
 	public Text getName(ItemStack stack) {
-		return getName();
+		var state = dynamicState(stack);
+		return CustomNameVisitor.of(state.customData())
+				.map(replacer -> replacer.replace(state.name()))
+				.map(Writer::nameToTranslatableText)
+				.orElseGet(this::getName);
 	}
 
 	@Override

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicPickaxeItem.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicPickaxeItem.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.state.StateProvider;
+import com.sigmundgranaas.forgero.minecraft.common.customdata.CustomNameVisitor;
 import com.sigmundgranaas.forgero.minecraft.common.item.ToolStateItem;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.StateWriter;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.Writer;
@@ -46,7 +47,11 @@ public class DynamicPickaxeItem extends PickaxeItem implements ToolStateItem {
 
 	@Override
 	public Text getName(ItemStack stack) {
-		return getName();
+		var state = dynamicState(stack);
+		return CustomNameVisitor.of(state.customData())
+				.map(replacer -> replacer.replace(state.name()))
+				.map(Writer::nameToTranslatableText)
+				.orElseGet(this::getName);
 	}
 
 	@Override

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicShovelItem.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicShovelItem.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.state.StateProvider;
+import com.sigmundgranaas.forgero.minecraft.common.customdata.CustomNameVisitor;
 import com.sigmundgranaas.forgero.minecraft.common.item.ToolStateItem;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.StateWriter;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.Writer;
@@ -46,7 +47,11 @@ public class DynamicShovelItem extends ShovelItem implements ToolStateItem {
 
 	@Override
 	public Text getName(ItemStack stack) {
-		return getName();
+		var state = dynamicState(stack);
+		return CustomNameVisitor.of(state.customData())
+				.map(replacer -> replacer.replace(state.name()))
+				.map(Writer::nameToTranslatableText)
+				.orElseGet(this::getName);
 	}
 
 	@Override

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicSwordItem.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/item/tool/DynamicSwordItem.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.state.StateProvider;
+import com.sigmundgranaas.forgero.minecraft.common.customdata.CustomNameVisitor;
 import com.sigmundgranaas.forgero.minecraft.common.item.ToolStateItem;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.StateWriter;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.Writer;
@@ -50,7 +51,11 @@ public class DynamicSwordItem extends SwordItem implements ToolStateItem {
 
 	@Override
 	public Text getName(ItemStack stack) {
-		return getName();
+		var state = dynamicState(stack);
+		return CustomNameVisitor.of(state.customData())
+				.map(replacer -> replacer.replace(state.name()))
+				.map(Writer::nameToTranslatableText)
+				.orElseGet(this::getName);
 	}
 }
 

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/tooltip/Writer.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/tooltip/Writer.java
@@ -1,5 +1,9 @@
 package com.sigmundgranaas.forgero.minecraft.common.tooltip;
 
+import static com.sigmundgranaas.forgero.core.identifier.Common.ELEMENT_SEPARATOR;
+
+import java.util.List;
+
 import com.sigmundgranaas.forgero.core.Forgero;
 import com.sigmundgranaas.forgero.core.state.State;
 
@@ -7,10 +11,6 @@ import net.minecraft.client.item.TooltipContext;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-
-import java.util.List;
-
-import static com.sigmundgranaas.forgero.core.identifier.Common.ELEMENT_SEPARATOR;
 
 public interface Writer {
 
@@ -25,6 +25,15 @@ public interface Writer {
 	static Text nameToTranslatableText(State state) {
 		MutableText text = Text.literal("");
 		for (String element : state.name().split("-")) {
+			text.append(Text.translatable(Writer.toTranslationKey(element)));
+			text.append(Text.translatable("util.forgero.name_separator"));
+		}
+		return text;
+	}
+
+	static Text nameToTranslatableText(String name) {
+		MutableText text = Text.literal("");
+		for (String element : name.split("-")) {
 			text.append(Text.translatable(Writer.toTranslationKey(element)));
 			text.append(Text.translatable("util.forgero.name_separator"));
 		}


### PR DESCRIPTION
Given the following custom data:
 
 ```
  "custom_data": {
      "name_replacement": {
        "from": "sword",
        "to": "knife"
      }
  }
```
  An item with the name "cobblestone-sword" will be transformed into "cobblestone-knife".