### PR TITLE
[Feature]: Support for "forgero:reach" attribute

### DIFF
--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/axe_head_base.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/axe_head_base.json
@@ -5,6 +5,11 @@
   "properties": {
     "attributes": [
       {
+        "id": "schematic-reach",
+        "type": "forgero:reach",
+        "value": 4
+      },
+      {
         "id": "schematic-attack_damage-composite",
         "type": "ATTACK_DAMAGE",
         "context": "COMPOSITE",

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/hoe_head_base.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/hoe_head_base.json
@@ -5,6 +5,11 @@
   "properties": {
     "attributes": [
       {
+        "id": "schematic-reach",
+        "type": "forgero:reach",
+        "value": 4
+      },
+      {
         "id": "schematic-attack_speed-composite",
         "type": "ATTACK_SPEED",
         "context": "COMPOSITE",

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/pickaxe_head_base.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/pickaxe_head_base.json
@@ -5,6 +5,11 @@
   "properties": {
     "attributes": [
       {
+        "id": "schematic-reach",
+        "type": "forgero:reach",
+        "value": 4
+      },
+      {
         "id": "schematic-attack_speed-composite",
         "type": "ATTACK_SPEED",
         "context": "COMPOSITE",

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/shovel_head_base.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/shovel_head_base.json
@@ -5,6 +5,11 @@
   "properties": {
     "attributes": [
       {
+        "id": "schematic-reach",
+        "type": "forgero:reach",
+        "value": 4
+      },
+      {
         "id": "schematic-attack_speed-composite",
         "type": "ATTACK_SPEED",
         "context": "COMPOSITE",

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade_base.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade_base.json
@@ -65,7 +65,13 @@
         ]
       }
     ],
-    "attributes": [],
+    "attributes": [
+      {
+        "id": "schematic-reach",
+        "type": "forgero:reach",
+        "value": 4
+      }
+    ],
     "features": [
       {
         "type": "minecraft:block_effectiveness",

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/ClientPlayerInteractionManagerReachMixin.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/ClientPlayerInteractionManagerReachMixin.java
@@ -1,0 +1,42 @@
+package com.sigmundgranaas.forgero.fabric.mixins;
+
+import com.sigmundgranaas.forgero.core.property.v2.ComputedAttribute;
+import com.sigmundgranaas.forgero.core.type.Type;
+import com.sigmundgranaas.forgero.minecraft.common.service.StateService;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientPlayerInteractionManager.class)
+public class ClientPlayerInteractionManagerReachMixin {
+	@Final
+	@Shadow
+	private MinecraftClient client;
+
+	@Inject(method = "getReachDistance", at = @At("RETURN"), cancellable = true)
+	private void adjustReachBasedOnWeapon(CallbackInfoReturnable<Float> cir) {
+		ClientPlayerEntity player = client.player;
+
+		if (player != null) {
+			ItemStack mainHandStack = player.getMainHandStack();
+
+			if (!mainHandStack.isEmpty()) {
+				StateService.INSTANCE.convert(mainHandStack)
+						.filter(state -> state.test(Type.HOLDABLE))
+						.map(container -> ComputedAttribute.of(container, "forgero:reach"))
+						.map(ComputedAttribute::asFloat)
+						.filter(value -> value > 0)
+						.map(reach -> player.isCreative() ? reach + 0.5 : reach)
+						.map(Double::floatValue)
+						.ifPresent(cir::setReturnValue);
+			}
+		}
+	}
+}

--- a/fabric/forgero-fabric-core/src/main/resources/forgero.mixins.json
+++ b/fabric/forgero-fabric-core/src/main/resources/forgero.mixins.json
@@ -24,6 +24,7 @@
     "RecipeManagerMixin"
   ],
   "client": [
+    "ClientPlayerInteractionManagerReachMixin",
     "ClientPlayNetworkGetTotemMixin",
     "ItemDescriptionInjector",
     "ItemModelGeneratorMixin",


### PR DESCRIPTION
Applies a default reach of 4 to all base schematics. Does not currently use composite attributes.