### PR TITLE
[Feature]: After use actions

### DIFF
--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPreInit.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPreInit.java
@@ -54,9 +54,15 @@ import com.sigmundgranaas.forgero.minecraft.common.handler.targeted.onHitEntity.
 import com.sigmundgranaas.forgero.minecraft.common.handler.targeted.onHitEntity.LightningStrikeHandler;
 import com.sigmundgranaas.forgero.minecraft.common.handler.targeted.onHitEntity.OnHitHandler;
 import com.sigmundgranaas.forgero.minecraft.common.handler.targeted.onHitEntity.StatusEffectHandler;
+import com.sigmundgranaas.forgero.minecraft.common.handler.used.AfterUseHandler;
+import com.sigmundgranaas.forgero.minecraft.common.handler.used.ConsumeStackHandler;
+import com.sigmundgranaas.forgero.minecraft.common.handler.used.ConsumeUpgradeHandler;
+import com.sigmundgranaas.forgero.minecraft.common.handler.used.CoolDownHandler;
+import com.sigmundgranaas.forgero.minecraft.common.handler.used.DamageHandler;
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.BlockPredicateMatcher;
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.DamagePercentagePredicate;
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.EntityPredicateMatcher;
+import com.sigmundgranaas.forgero.minecraft.common.match.predicate.RandomPredicate;
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.WeatherPredicate;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.v2.PredicateWriterFactory;
 
@@ -94,7 +100,7 @@ public class ForgeroPreInit implements ForgeroPreInitializationEntryPoint {
 		PredicateFactory.register(BlockPredicateMatcher.BlockPredicateBuilder::new);
 		PredicateFactory.register(WeatherPredicate.WeatherPredicateBuilder::new);
 		PredicateFactory.register(CanMineFilter.CanMineFilterBuilder::new);
-
+		PredicateFactory.register(RandomPredicate.RandomPredicatePredicateBuilder::new);
 		//Writers
 		PredicateWriterFactory.register(EntityPredicateMatcher.EntityPredicateWriter::builder);
 		PredicateWriterFactory.register(BlockPredicateMatcher.BlockPredicateWriter::builder);
@@ -130,6 +136,13 @@ public class ForgeroPreInit implements ForgeroPreInitializationEntryPoint {
 		HandlerBuilderRegistry.register(OnHitBlockHandler.KEY, FireHandler.TYPE, FireHandler.BUILDER);
 		HandlerBuilderRegistry.register(OnHitBlockHandler.KEY, ParticleHandler.TYPE, ParticleHandler.BUILDER);
 		HandlerBuilderRegistry.register(OnHitBlockHandler.KEY, SoundHandler.TYPE, SoundHandler.BUILDER);
+
+		// After use
+		HandlerBuilderRegistry.register(AfterUseHandler.KEY, ConsumeStackHandler.TYPE, ConsumeStackHandler.BUILDER);
+		HandlerBuilderRegistry.register(AfterUseHandler.KEY, ConsumeUpgradeHandler.TYPE, ConsumeUpgradeHandler.BUILDER);
+		HandlerBuilderRegistry.register(AfterUseHandler.KEY, DamageHandler.TYPE, DamageHandler.BUILDER);
+		HandlerBuilderRegistry.register(AfterUseHandler.KEY, CoolDownHandler.TYPE, CoolDownHandler.BUILDER);
+
 
 		// On entity tick
 		HandlerBuilderRegistry.register(EntityHandler.KEY, MagneticHandler.TYPE, MagneticHandler.BUILDER);

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/OnEntityHitMixin.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/OnEntityHitMixin.java
@@ -1,18 +1,21 @@
 package com.sigmundgranaas.forgero.fabric.mixins;
 
+import static com.sigmundgranaas.forgero.minecraft.common.feature.FeatureUtils.streamFeature;
+import static com.sigmundgranaas.forgero.minecraft.common.match.MinecraftContextKeys.*;
+
 import com.sigmundgranaas.forgero.core.util.match.MatchContext;
 import com.sigmundgranaas.forgero.minecraft.common.feature.OnHitEntityFeature;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static com.sigmundgranaas.forgero.minecraft.common.feature.FeatureUtils.streamFeature;
-import static com.sigmundgranaas.forgero.minecraft.common.match.MinecraftContextKeys.*;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Hand;
 
 @Mixin(LivingEntity.class)
 public abstract class OnEntityHitMixin {
@@ -29,6 +32,9 @@ public abstract class OnEntityHitMixin {
 		Entity attacker = source.getAttacker();
 		if (attacker != null && (cir.getReturnValue() || attacker.getWorld().isClient) && attacker instanceof LivingEntity entity) {
 			ItemStack main = entity.getMainHandStack();
+			if (entity instanceof ServerPlayerEntity player && player.getItemCooldownManager().isCoolingDown(main.getItem())) {
+				return;
+			}
 			Entity target = (Entity) (Object) this;
 			MatchContext context = MatchContext.of()
 					.put(ENTITY, entity)
@@ -36,7 +42,10 @@ public abstract class OnEntityHitMixin {
 					.put(ENTITY_TARGET, target);
 
 			streamFeature(main, context, OnHitEntityFeature.KEY)
-					.forEach(handler -> handler.onHit(entity, entity.world, target));
+					.forEach(handler -> {
+						handler.onHit(entity, entity.world, target);
+						handler.handle(entity, main, Hand.MAIN_HAND);
+					});
 		}
 	}
 }

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/PlayerEntityAttackMixin.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/PlayerEntityAttackMixin.java
@@ -1,19 +1,20 @@
 package com.sigmundgranaas.forgero.fabric.mixins;
 
-import static com.sigmundgranaas.forgero.minecraft.common.match.MinecraftContextKeys.*;
-
 import com.sigmundgranaas.forgero.core.property.v2.attribute.attributes.AttackDamage;
 import com.sigmundgranaas.forgero.core.util.match.MatchContext;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import com.sigmundgranaas.forgero.minecraft.common.item.StateItem;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import static com.sigmundgranaas.forgero.minecraft.common.match.MinecraftContextKeys.*;
 
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityAttackMixin {
@@ -38,6 +39,8 @@ public abstract class PlayerEntityAttackMixin {
 		}
 		return x;
 	}
+
+
 }
 
 

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/PlayerServerInteractionManagerMixin.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/PlayerServerInteractionManagerMixin.java
@@ -1,8 +1,14 @@
 package com.sigmundgranaas.forgero.fabric.mixins;
 
+import static com.sigmundgranaas.forgero.minecraft.common.feature.FeatureUtils.streamFeature;
+import static com.sigmundgranaas.forgero.minecraft.common.match.MinecraftContextKeys.*;
+
+import com.sigmundgranaas.forgero.core.util.match.MatchContext;
+import com.sigmundgranaas.forgero.minecraft.common.feature.OnHitBlockFeature;
 import com.sigmundgranaas.forgero.minecraft.common.toolhandler.PropertyHelper;
 import com.sigmundgranaas.forgero.minecraft.common.toolhandler.SoulHandler;
 import com.sigmundgranaas.forgero.minecraft.common.toolhandler.block.ToolBlockHandler;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -10,10 +16,12 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.ServerPlayerInteractionManager;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
@@ -29,7 +37,7 @@ public abstract class PlayerServerInteractionManagerMixin {
 	public abstract void finishMining(BlockPos pos, int sequence, String reason);
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerInteractionManager;finishMining(Lnet/minecraft/util/math/BlockPos;ILjava/lang/String;)V"), method = "processBlockBreakingAction")
-	public void processBlockBreakingAction(BlockPos pos, PlayerActionC2SPacket.Action action, Direction direction, int worldHeight, int sequence, CallbackInfo ci) {
+	public void forgero$processBlockBreakingAction(BlockPos pos, PlayerActionC2SPacket.Action action, Direction direction, int worldHeight, int sequence, CallbackInfo ci) {
 		var soulHandler = SoulHandler.of(player.getMainHandStack());
 		soulHandler.ifPresent(soul -> soul.processBlockBreak(pos, world, player));
 		PropertyHelper.ofPlayerHands(player)
@@ -38,5 +46,26 @@ public abstract class PlayerServerInteractionManagerMixin {
 					soulHandler.ifPresent(soul -> soul.processBlockBreak(info, world, player));
 					this.finishMining(info, sequence, "destroyed");
 				}).cleanUp());
+	}
+
+	@Inject(method = "processBlockBreakingAction", at = @At(value = "INVOKE",
+			target = "Lnet/minecraft/server/world/ServerWorld;getBlockState(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/BlockState;",
+			opcode = Opcodes.INVOKEVIRTUAL, shift = At.Shift.AFTER))
+	private void forgero$onStartMining(BlockPos pos, PlayerActionC2SPacket.Action action, Direction direction, int worldHeight, int sequence, CallbackInfo ci) {
+		ServerPlayerEntity entity = player;
+		ItemStack main = entity.getMainHandStack();
+		if (player.getItemCooldownManager().isCoolingDown(main.getItem())) {
+			return;
+		}
+		MatchContext context = MatchContext.of()
+				.put(ENTITY, entity)
+				.put(WORLD, entity.world)
+				.put(BLOCK_TARGET, pos);
+
+		streamFeature(main, context, OnHitBlockFeature.KEY)
+				.forEach(handler -> {
+					handler.onHit(entity, entity.world, pos);
+					handler.handle(entity, main, Hand.MAIN_HAND);
+				});
 	}
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/feature/FeatureUtils.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/feature/FeatureUtils.java
@@ -31,6 +31,16 @@ public class FeatureUtils {
 				.features(key);
 	}
 
+	public static <T extends Feature> Stream<T> streamFeatureWithSource(ItemStack stack, MatchContext context, ClassKey<T> key) {
+		var state = StateService.INSTANCE.convert(stack);
+		if (state.isEmpty() || !FeatureCache.check(key, state.get())) {
+			return Stream.empty();
+		}
+
+		return state.get().stream(Matchable.DEFAULT_TRUE, context)
+				.features(key);
+	}
+
 	public static <T extends Feature> Stream<T> streamFeature(PropertyContainer container, MatchContext context, ClassKey<T> key) {
 		return container.stream(Matchable.DEFAULT_TRUE, context)
 				.features(key);

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/feature/OnHitEntityFeature.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/feature/OnHitEntityFeature.java
@@ -11,20 +11,26 @@ import com.sigmundgranaas.forgero.core.property.v2.feature.ClassKey;
 import com.sigmundgranaas.forgero.core.property.v2.feature.FeatureBuilder;
 import com.sigmundgranaas.forgero.core.property.v2.feature.HandlerBuilder;
 import com.sigmundgranaas.forgero.minecraft.common.handler.targeted.onHitEntity.OnHitHandler;
+import com.sigmundgranaas.forgero.minecraft.common.handler.used.AfterUseHandler;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 
-public class OnHitEntityFeature extends BasePredicateFeature implements OnHitHandler {
+public class OnHitEntityFeature extends BasePredicateFeature implements OnHitHandler, AfterUseHandler {
 	public static final String ON_HIT_TYPE = "minecraft:on_hit";
 	public static final ClassKey<OnHitEntityFeature> KEY = new ClassKey<>(ON_HIT_TYPE, OnHitEntityFeature.class);
 	public static final String ON_HIT = "on_hit";
+
 	public static final FeatureBuilder<OnHitEntityFeature> BUILDER = FeatureBuilder.of(ON_HIT_TYPE, OnHitEntityFeature::buildFromBase);
 	private final List<OnHitHandler> handler;
+	private final List<AfterUseHandler> afterUseHandlers;
 
-	public OnHitEntityFeature(BasePredicateData data, List<OnHitHandler> handler) {
+	public OnHitEntityFeature(BasePredicateData data, List<OnHitHandler> handler, List<AfterUseHandler> afterUseHandlers) {
 		super(data);
 		this.handler = handler;
+		this.afterUseHandlers = afterUseHandlers;
 		if (!data.type().equals(ON_HIT_TYPE)) {
 			throw new IllegalArgumentException("Type needs to be: " + ON_HIT_TYPE);
 		}
@@ -32,7 +38,9 @@ public class OnHitEntityFeature extends BasePredicateFeature implements OnHitHan
 
 	private static OnHitEntityFeature buildFromBase(BasePredicateData data, JsonElement element) {
 		List<OnHitHandler> handler = buildHandlerFromJson(element, ON_HIT, obj -> HandlerBuilder.DEFAULT.build(OnHitHandler.KEY, obj));
-		return new OnHitEntityFeature(data, handler);
+		List<AfterUseHandler> afterUseHandler = buildHandlerFromJson(element, AFTER_USE, obj -> HandlerBuilder.DEFAULT.build(AfterUseHandler.KEY, obj));
+
+		return new OnHitEntityFeature(data, handler, afterUseHandler);
 	}
 
 	@Override
@@ -43,5 +51,10 @@ public class OnHitEntityFeature extends BasePredicateFeature implements OnHitHan
 	@Override
 	public void onHit(Entity root, World world, Entity target) {
 		handler.forEach(sub -> sub.onHit(root, world, target));
+	}
+
+	@Override
+	public void handle(Entity source, ItemStack target, Hand hand) {
+		afterUseHandlers.forEach(sub -> sub.handle(source, target, hand));
 	}
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/targeted/ExplosionHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/targeted/ExplosionHandler.java
@@ -9,9 +9,12 @@ import lombok.Getter;
 import lombok.experimental.Accessors;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.explosion.Explosion;
+import net.minecraft.world.explosion.ExplosionBehavior;
 
 /**
  * Represents a handler that triggers an explosion around entities upon hitting a target.
@@ -24,7 +27,7 @@ import net.minecraft.world.explosion.Explosion;
  *   "on_hit": {
  *     "type": "minecraft:explosion",
  *     "target": "minecraft:targeted_entity",
- *     "power": 3
+ *     "power": 10
  *   }
  * }
  * </pre>
@@ -82,8 +85,8 @@ public class ExplosionHandler implements OnHitHandler, OnHitBlockHandler {
 
 	@Override
 	public void onHit(Entity root, World world, BlockPos pos) {
-		if ("minecraft:targeted_entity".equals(target) && !world.isClient) {
-			world.createExplosion(root, pos.getX(), pos.getY(), pos.getZ(), power, Explosion.DestructionType.BREAK);
+		if (!world.isClient && root instanceof LivingEntity living) {
+			world.createExplosion(root, DamageSource.explosion(living), new ExplosionBehavior(), pos.getX(), pos.getY() + 1, pos.getZ(), power, false, Explosion.DestructionType.BREAK);
 		}
 	}
 }

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/AfterUseHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/AfterUseHandler.java
@@ -1,0 +1,16 @@
+package com.sigmundgranaas.forgero.minecraft.common.handler.used;
+
+import com.sigmundgranaas.forgero.core.property.v2.feature.ClassKey;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+
+public interface AfterUseHandler {
+	AfterUseHandler DEFAULT = (Entity source, ItemStack target, Hand hand) -> {
+	};
+	String AFTER_USE = "after_use";
+	ClassKey<AfterUseHandler> KEY = new ClassKey<>("minecraft:after_use", AfterUseHandler.class);
+
+	void handle(Entity source, ItemStack target, Hand hand);
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/ConsumeStackHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/ConsumeStackHandler.java
@@ -14,7 +14,7 @@ import net.minecraft.util.Hand;
 
 
 /**
- * Represents a handler that damages the ItemStack after it has been used.
+ * Represents a handler that consumes an entire stack after it has been used.
  *
  * <p>Example JSON configuration:
  * <pre>
@@ -37,7 +37,7 @@ import net.minecraft.util.Hand;
 public class ConsumeStackHandler implements AfterUseHandler {
 	public static final String TYPE = "minecraft:consume_stack";
 	public static final JsonBuilder<ConsumeStackHandler> BUILDER = HandlerBuilder.fromObject(ConsumeStackHandler.class, (json) -> new ConsumeStackHandler());
-	
+
 	@Override
 	public void handle(Entity source, ItemStack target, Hand hand) {
 		if (source instanceof LivingEntity livingEntity) {

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/ConsumeStackHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/ConsumeStackHandler.java
@@ -1,0 +1,51 @@
+package com.sigmundgranaas.forgero.minecraft.common.handler.used;
+
+import com.sigmundgranaas.forgero.core.property.v2.feature.HandlerBuilder;
+import com.sigmundgranaas.forgero.core.property.v2.feature.JsonBuilder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.ArrowEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+
+
+/**
+ * Represents a handler that damages the ItemStack after it has been used.
+ *
+ * <p>Example JSON configuration:
+ * <pre>
+ * {
+ *   "type": "minecraft:on_hit",
+ *   "on_hit": {
+ *     "type": "minecraft:explosion",
+ *     "target": "minecraft:targeted_entity",
+ *     "power": 3
+ *   }
+ *   "after_use": {
+ *     "type": "minecraft:consume_stack"
+ *   }
+ * }
+ * </pre>
+ * </p>
+ */
+@Getter
+@Accessors(fluent = true)
+public class ConsumeStackHandler implements AfterUseHandler {
+	public static final String TYPE = "minecraft:consume_stack";
+	public static final JsonBuilder<ConsumeStackHandler> BUILDER = HandlerBuilder.fromObject(ConsumeStackHandler.class, (json) -> new ConsumeStackHandler());
+	
+	@Override
+	public void handle(Entity source, ItemStack target, Hand hand) {
+		if (source instanceof LivingEntity livingEntity) {
+			livingEntity.setStackInHand(hand, ItemStack.EMPTY);
+		} else if (source instanceof ItemEntity item) {
+			item.remove(Entity.RemovalReason.DISCARDED);
+		} else if (source instanceof ArrowEntity arrow) {
+			arrow.remove(Entity.RemovalReason.DISCARDED);
+		}
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/ConsumeUpgradeHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/ConsumeUpgradeHandler.java
@@ -1,0 +1,70 @@
+package com.sigmundgranaas.forgero.minecraft.common.handler.used;
+
+import com.google.gson.JsonObject;
+import com.sigmundgranaas.forgero.core.property.v2.feature.HandlerBuilder;
+import com.sigmundgranaas.forgero.core.property.v2.feature.JsonBuilder;
+import com.sigmundgranaas.forgero.core.state.Composite;
+import com.sigmundgranaas.forgero.minecraft.common.service.StateService;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+
+/**
+ * Represents a handler that removes an upgrade after use.
+ *
+ * <p>Example JSON configuration:
+ * <pre>
+ * {
+ *   "type": "minecraft:on_hit",
+ *   "on_hit": {
+ *     "type": "minecraft:explosion",
+ *     "target": "minecraft:targeted_entity",
+ *     "power": 3
+ *   }
+ *   "after_use": {
+ *     "type": "minecraft:consume_upgrade",
+ *     "id": "forgero:undying_totem"
+ *   }
+ * }
+ * </pre>
+ * </p>
+ */
+@Getter
+@Accessors(fluent = true)
+public class ConsumeUpgradeHandler implements AfterUseHandler {
+	public static final String TYPE = "forgero:consume_upgrade";
+	public static final JsonBuilder<ConsumeUpgradeHandler> BUILDER = HandlerBuilder.fromObject(ConsumeUpgradeHandler.class, ConsumeUpgradeHandler::fromJson);
+
+
+	private final String identifier;
+
+	public ConsumeUpgradeHandler(String identifier) {
+		this.identifier = identifier;
+	}
+
+	/**
+	 * Constructs an {@link DamageHandler} from a JSON object.
+	 *
+	 * @param json The JSON object.
+	 * @return A new instance of {@link DamageHandler}.
+	 */
+	public static ConsumeUpgradeHandler fromJson(JsonObject json) {
+		String id = json.get("id").getAsString();
+		return new ConsumeUpgradeHandler(id);
+	}
+
+	@Override
+	public void handle(Entity source, ItemStack target, Hand hand) {
+		if (source instanceof LivingEntity livingEntity) {
+			var state = StateService.INSTANCE.convert(target);
+			if (state.isPresent() && state.get() instanceof Composite composite) {
+				var newState = composite.removeUpgrade(identifier);
+				livingEntity.setStackInHand(hand, StateService.INSTANCE.update(newState, target));
+			}
+		}
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/CoolDownHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/CoolDownHandler.java
@@ -1,0 +1,65 @@
+package com.sigmundgranaas.forgero.minecraft.common.handler.used;
+
+import com.google.gson.JsonObject;
+import com.sigmundgranaas.forgero.core.property.v2.feature.HandlerBuilder;
+import com.sigmundgranaas.forgero.core.property.v2.feature.JsonBuilder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.ItemCooldownManager;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Hand;
+
+
+/**
+ * Represents a handler that sets a cooldown on the item after it has been used.
+ *
+ * <p>Example JSON configuration:
+ * <pre>
+ * {
+ *   "type": "minecraft:on_hit",
+ *   "on_hit": {
+ *     "type": "minecraft:explosion",
+ *     "target": "minecraft:targeted_entity",
+ *     "power": 3
+ *   }
+ *   "after_use": {
+ *     "type": "minecraft:cooldown",
+ *     "duration": 50
+ *   }
+ * }
+ * </pre>
+ * </p>
+ */
+@Getter
+@Accessors(fluent = true)
+public class CoolDownHandler implements AfterUseHandler {
+	public static final String TYPE = "minecraft:cooldown";
+	public static final JsonBuilder<CoolDownHandler> BUILDER = HandlerBuilder.fromObject(CoolDownHandler.class, CoolDownHandler::fromJson);
+	private final int duration;
+
+	public CoolDownHandler(int duration) {
+		this.duration = duration;
+	}
+
+	/**
+	 * Constructs an {@link CoolDownHandler} from a JSON object.
+	 *
+	 * @param json The JSON object.
+	 * @return A new instance of {@link CoolDownHandler}.
+	 */
+	public static CoolDownHandler fromJson(JsonObject json) {
+		int damage = json.get("duration").getAsInt();
+		return new CoolDownHandler(damage);
+	}
+
+	@Override
+	public void handle(Entity source, ItemStack target, Hand hand) {
+		if (source instanceof ServerPlayerEntity player) {
+			ItemCooldownManager cooldownManager = player.getItemCooldownManager();
+			cooldownManager.set(target.getItem(), duration);
+		}
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/DamageHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/handler/used/DamageHandler.java
@@ -1,0 +1,65 @@
+package com.sigmundgranaas.forgero.minecraft.common.handler.used;
+
+import com.google.gson.JsonObject;
+import com.sigmundgranaas.forgero.core.property.v2.feature.HandlerBuilder;
+import com.sigmundgranaas.forgero.core.property.v2.feature.JsonBuilder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+
+/**
+ * Represents a handler that damages the ItemStack after it has been used.
+ *
+ * <p>Example JSON configuration:
+ * <pre>
+ * {
+ *   "type": "minecraft:on_hit",
+ *   "on_hit": {
+ *     "type": "minecraft:explosion",
+ *     "target": "minecraft:targeted_entity",
+ *     "power": 3
+ *   }
+ *   "after_use": {
+ *     "type": "minecraft:stack_damage",
+ *     "damage": 50
+ *   }
+ * }
+ * </pre>
+ * </p>
+ */
+@Getter
+@Accessors(fluent = true)
+public class DamageHandler implements AfterUseHandler {
+	public static final String TYPE = "minecraft:stack_damage";
+	public static final JsonBuilder<DamageHandler> BUILDER = HandlerBuilder.fromObject(DamageHandler.class, DamageHandler::fromJson);
+
+	private final int damage;
+
+	public DamageHandler(int damage) {
+		this.damage = damage;
+	}
+
+	/**
+	 * Constructs an {@link DamageHandler} from a JSON object.
+	 *
+	 * @param json The JSON object.
+	 * @return A new instance of {@link DamageHandler}.
+	 */
+	public static DamageHandler fromJson(JsonObject json) {
+		int damage = json.get("damage").getAsInt();
+		return new DamageHandler(damage);
+	}
+
+	@Override
+	public void handle(Entity source, ItemStack target, Hand hand) {
+		if (source instanceof LivingEntity livingEntity) {
+			target.damage(damage, livingEntity, (entity) -> entity.sendToolBreakStatus(hand));
+		} else {
+			target.setDamage(target.getDamage() + damage);
+		}
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/match/predicate/EntityEffectPredicate.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/match/predicate/EntityEffectPredicate.java
@@ -92,9 +92,6 @@ public class EntityEffectPredicate {
 		@Nullable
 		private final Boolean visible;
 
-		public EffectData() {
-			this(NumberRange.IntRange.ANY, NumberRange.IntRange.ANY, null, null);
-		}
 
 		public EffectData(NumberRange.IntRange amplifier, NumberRange.IntRange duration, @Nullable Boolean ambient, @Nullable Boolean visible) {
 			this.amplifier = amplifier;

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/match/predicate/RandomPredicate.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/match/predicate/RandomPredicate.java
@@ -1,0 +1,34 @@
+package com.sigmundgranaas.forgero.minecraft.common.match.predicate;
+
+import java.util.Optional;
+
+import com.google.gson.JsonElement;
+import com.sigmundgranaas.forgero.core.model.match.builders.ElementParser;
+import com.sigmundgranaas.forgero.core.model.match.builders.PredicateBuilder;
+import com.sigmundgranaas.forgero.core.util.match.MatchContext;
+import com.sigmundgranaas.forgero.core.util.match.Matchable;
+
+public record RandomPredicate(float value) implements Matchable {
+	public static String ID = "forgero:random";
+
+	@Override
+	public boolean test(Matchable match, MatchContext context) {
+		return Math.random() < value;
+	}
+
+	@Override
+	public boolean isDynamic() {
+		return true;
+	}
+
+	/**
+	 * Attempts to create a Matchable of type RandomPredicate from a JsonElement.
+	 */
+	public static class RandomPredicatePredicateBuilder implements PredicateBuilder {
+		@Override
+		public Optional<Matchable> create(JsonElement element) {
+			return ElementParser.fromIdentifiedElement(element, ID)
+					.map(jsonObject -> new RandomPredicate(jsonObject.get("value").getAsFloat()));
+		}
+	}
+}


### PR DESCRIPTION
This pr adds the following new field: `after_use`
It also adds these handler for it:
- `"minecraft:consume_stack"` - consumes the originating stack, or equivalent if triggered from an entity
- `"forgero:consume_upgrade"` - consumes an upgrade of a given id. Useful for removing one time use upgrades
- `"minecraft:cooldown"` - Puts a cooldown in ticks on the item that was used
- `"minecraft:stack_damage"` - Puts damage on the stack that was used. Can be set as direct damage, or percentage.

This also adds the `forgero:chance` predicate

closes #750