### PR TITLE
[Feature]: Static textures as children of model elements

### DIFF
--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/client/ForgeroClient.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/client/ForgeroClient.java
@@ -4,7 +4,9 @@ import com.google.common.collect.ImmutableList;
 import com.sigmundgranaas.forgero.core.Forgero;
 import com.sigmundgranaas.forgero.core.ForgeroStateRegistry;
 import com.sigmundgranaas.forgero.core.model.ModelRegistry;
+import com.sigmundgranaas.forgero.core.model.ModelTemplate;
 import com.sigmundgranaas.forgero.core.model.PaletteTemplateModel;
+import com.sigmundgranaas.forgero.core.model.TextureModel;
 import com.sigmundgranaas.forgero.core.resource.PipelineBuilder;
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.texture.V2.TextureGenerator;
@@ -34,6 +36,7 @@ import net.minecraft.resource.ResourceType;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.util.Identifier;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -44,7 +47,7 @@ import static com.sigmundgranaas.forgero.minecraft.common.block.upgradestation.U
 
 @Environment(EnvType.CLIENT)
 public class ForgeroClient implements ClientModInitializer {
-	public static Map<String, PaletteTemplateModel> TEXTURES = new HashMap<>();
+	public static Map<String, ModelTemplate> TEXTURES = new HashMap<>();
 	public static Map<String, String> PALETTE_REMAP = new HashMap<>();
 
 	@Override
@@ -82,13 +85,17 @@ public class ForgeroClient implements ClientModInitializer {
 				.map(node -> node.getResources(State.class))
 				.orElse(ImmutableList.<State>builder().build());
 		for (State material : materials) {
-			ForgeroClient.TEXTURES.put(String.format("forgero:%s-repair_kit.png", material.name()), new PaletteTemplateModel(material.name(), "repair_kit.png", 30, null, 16, null));
+			ForgeroClient.TEXTURES.put(String.format("forgero:%s-repair_kit.png", material.name()), new PaletteTemplateModel(material.name(), "repair_kit.png", 30, null, 16, null, Collections.emptyList()));
 		}
 
 		PALETTE_REMAP.putAll(modelRegistry.getPaletteRemapper());
 		TEXTURES.putAll(modelRegistry.getTextures());
 		TEXTURES.values().forEach(texture -> {
-			ClientSpriteRegistryCallback.event(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE).register((atlasTexture, atlasRegistry) -> atlasRegistry.register(new Identifier(texture.nameSpace(), "item/" + texture.name().replace(".png", ""))));
+			if(texture instanceof PaletteTemplateModel paletteTemplateModel){
+				ClientSpriteRegistryCallback.event(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE).register((atlasTexture, atlasRegistry) -> atlasRegistry.register(new Identifier(paletteTemplateModel.nameSpace(), "item/" + paletteTemplateModel.name().replace(".png", ""))));
+			}else if(texture instanceof TextureModel model){
+				ClientSpriteRegistryCallback.event(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE).register((atlasTexture, atlasRegistry) -> atlasRegistry.register(new Identifier(model.nameSpace(), model.name().replace(".png", ""))));
+			}
 		});
 		ClientSpriteRegistryCallback.event(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE).register((atlasTexture, atlasRegistry) -> atlasRegistry.register(new Identifier(Forgero.NAMESPACE, "item/" + "repair_kit_leather_base")));
 		ClientSpriteRegistryCallback.event(PlayerScreenHandler.BLOCK_ATLAS_TEXTURE).register((atlasTexture, atlasRegistry) -> atlasRegistry.register(new Identifier(Forgero.NAMESPACE, "item/" + "repair_kit_needle_base")));

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/LifecycleResourceManagerImplMixin.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/LifecycleResourceManagerImplMixin.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.sigmundgranaas.forgero.core.model.ModelTemplate;
+import com.sigmundgranaas.forgero.core.model.PaletteTemplateModel;
 import com.sigmundgranaas.forgero.core.texture.V2.FileLoader;
 import com.sigmundgranaas.forgero.core.texture.V2.TextureGenerator;
 import com.sigmundgranaas.forgero.fabric.client.ForgeroClient;
@@ -28,17 +30,20 @@ public abstract class LifecycleResourceManagerImplMixin {
 		if (id.getPath().contains(".png") && cir.getReturnValue().isEmpty()) {
 			var textureId = id.getPath().replace("textures/item/", id.getNamespace() + ":");
 			if (ForgeroClient.TEXTURES.containsKey(textureId)) {
-
-				FileLoader loader = new ResourceLoadedFileService();
-				var texture = TextureGenerator.getInstance(loader, ForgeroClient.PALETTE_REMAP).getTexture(ForgeroClient.TEXTURES.get(textureId));
-				if (texture.isPresent()) {
-					var metadata = TextureGenerator.getInstance(loader, ForgeroClient.PALETTE_REMAP).getMetadata(ForgeroClient.TEXTURES.get(textureId), ".mcmeta");
-					Resource resource;
-					resource = metadata
-							.map(object -> new Resource(id.getNamespace(), texture.get()::getStream, convert(object)))
-							.orElseGet(() -> new Resource(id.getNamespace(), texture.get()::getStream));
-					cir.setReturnValue(Optional.of(resource));
+				ModelTemplate template = ForgeroClient.TEXTURES.get(textureId);
+				if(template instanceof PaletteTemplateModel paletteTemplateModel){
+					FileLoader loader = new ResourceLoadedFileService();
+					var texture = TextureGenerator.getInstance(loader, ForgeroClient.PALETTE_REMAP).getTexture(paletteTemplateModel);
+					if (texture.isPresent()) {
+						var metadata = TextureGenerator.getInstance(loader, ForgeroClient.PALETTE_REMAP).getMetadata(paletteTemplateModel, ".mcmeta");
+						Resource resource;
+						resource = metadata
+								.map(object -> new Resource(id.getNamespace(), texture.get()::getStream, convert(object)))
+								.orElseGet(() -> new Resource(id.getNamespace(), texture.get()::getStream));
+						cir.setReturnValue(Optional.of(resource));
+					}
 				}
+
 			}
 		}
 	}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/client/model/CompositeModelVariant.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/client/model/CompositeModelVariant.java
@@ -6,6 +6,7 @@ import com.google.common.cache.LoadingCache;
 import com.sigmundgranaas.forgero.core.ForgeroStateRegistry;
 import com.sigmundgranaas.forgero.core.configuration.ForgeroConfigurationLoader;
 import com.sigmundgranaas.forgero.core.model.*;
+import com.sigmundgranaas.forgero.core.texture.V2.Texture;
 import com.sigmundgranaas.forgero.core.util.match.MatchContext;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import com.sigmundgranaas.forgero.core.util.match.MutableMatchContext;
@@ -206,7 +207,7 @@ public class CompositeModelVariant extends ForgeroCustomModelProvider {
 	}
 
 	private Optional<UnbakedDynamicModel> modelConverter(ModelTemplate input) {
-		var textureList = new ArrayList<PaletteTemplateModel>();
+		var textureList = new ArrayList<ModelTemplate>();
 		if (input instanceof CompositeModelTemplate model) {
 			model.getModels().forEach(template -> textureCollector(template, textureList));
 			var unbakedModel = new Unbaked2DTexturedModel(loader, textureGetter, textureList, "dummy");
@@ -219,22 +220,29 @@ public class CompositeModelVariant extends ForgeroCustomModelProvider {
 		return Optional.empty();
 	}
 
-	private void textureCollector(ModelTemplate template, List<PaletteTemplateModel> accumulator) {
+	private void textureCollector(ModelTemplate template, List<ModelTemplate> accumulator) {
 		if (template instanceof PaletteTemplateModel palette) {
 			textureCollector(palette, accumulator);
 		} else if (template instanceof CompositeModelTemplate composite) {
 			textureCollector(composite, accumulator);
+		} else if(template instanceof TextureModel textureModel){
+			textureCollector(textureModel, accumulator);
 		}
 	}
 
-	private void textureCollector(PaletteTemplateModel template, List<PaletteTemplateModel> accumulator) {
+	private void textureCollector(PaletteTemplateModel template, List<ModelTemplate> accumulator) {
 		accumulator.add(template);
+		template.children().forEach(child -> textureCollector(child, accumulator));
 	}
 
-	private void textureCollector(CompositeModelTemplate template, List<PaletteTemplateModel> accumulator) {
+	private void textureCollector(CompositeModelTemplate template, List<ModelTemplate> accumulator) {
 		template.getModels().forEach(model -> textureCollector(model, accumulator));
 	}
 
+	private void textureCollector(TextureModel template, List<ModelTemplate> accumulator) {
+		accumulator.add(template);
+		template.children().forEach(child -> textureCollector(child, accumulator));
+	}
 }
 
 

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelRegistry.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelRegistry.java
@@ -17,11 +17,14 @@ import com.sigmundgranaas.forgero.core.state.Identifiable;
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.type.TypeTree;
 import com.sigmundgranaas.forgero.core.util.match.MatchContext;
+import lombok.Getter;
 
 public class ModelRegistry {
 	private final HashMap<String, ModelMatcher> modelMap;
-	private final Map<String, PaletteTemplateModel> textures;
+	@Getter
+	private final Map<String, ModelTemplate> textures;
 
+	@Getter
 	private final Map<String, String> paletteRemapper;
 	private final Map<String, PaletteData> palettes;
 
@@ -117,13 +120,5 @@ public class ModelRegistry {
 			return Optional.of(MultipleModelMatcher.of(tree.find(state.type().typeName()).map(node -> node.getResources(ModelMatcher.class)).orElse(ImmutableList.<ModelMatcher>builder().build())));
 		}
 		return Optional.empty();
-	}
-
-	public Map<String, PaletteTemplateModel> getTextures() {
-		return textures;
-	}
-
-	public Map<String, String> getPaletteRemapper() {
-		return paletteRemapper;
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/TextureModel.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/TextureModel.java
@@ -12,13 +12,12 @@ import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public record PaletteTemplateModel(String palette,
-								   String template,
-								   int order,
-								   @Nullable Offset offset,
-								   @Nullable Integer resolution,
-								   @Nullable JsonObject displayOverrides,
-                                   List<ModelTemplate> children) implements ModelTemplate, ModelMatcher, Identifiable {
+public record TextureModel(String texture,
+                           int order,
+                           @Nullable Offset offset,
+                           @Nullable Integer resolution,
+                           @Nullable JsonObject displayOverrides,
+                           List<ModelTemplate> children) implements ModelTemplate, ModelMatcher, Identifiable {
 
 	@Override
 	public Optional<Offset> getOffset() {
@@ -52,13 +51,24 @@ public record PaletteTemplateModel(String palette,
 
 	@Override
 	public String name() {
-		return String.format("%s-%s", palette, template);
+		var split = texture().split(":");
+		if(split.length > 1){
+			return split[1];
+		}else {
+			return texture();
+		}
 	}
 
 	@Override
 	public String nameSpace() {
-		return String.format("%s", Forgero.NAMESPACE);
+		var split = texture.split(":");
+		if(split.length > 1){
+			return split[0];
+		}else {
+			return Forgero.NAMESPACE;
+		}
 	}
+
 
 	@Override
 	public String toString() {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/ModelData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/ModelData.java
@@ -49,6 +49,15 @@ public class ModelData {
 	@Nullable
 	private String palette = Identifiers.EMPTY_IDENTIFIER;
 
+	@Builder.Default
+	@Nullable
+	@SerializedName(value = "children", alternate = {"textures"})
+	private List<ModelData> children = Collections.emptyList();
+
+	@Builder.Default
+	@Nullable
+	private String texture =  Identifiers.EMPTY_IDENTIFIER;
+
 	@Nullable
 	@SerializedName(value = "display_overrides", alternate = "display")
 	private JsonObject displayOverrides;
@@ -77,7 +86,6 @@ public class ModelData {
 		return order;
 	}
 
-
 	public List<ModelEntryData> getVariants() {
 		return Objects.requireNonNullElse(variants, Collections.emptyList());
 	}
@@ -99,4 +107,15 @@ public class ModelData {
 	public String getPalette() {
 		return Objects.requireNonNullElse(palette, Identifiers.EMPTY_IDENTIFIER);
 	}
+
+	@NotNull
+	public List<ModelData> getChildren() {
+		return Objects.requireNonNullElse(children, Collections.emptyList());
+	}
+
+	@NotNull
+	public String getTexture() {
+		return Objects.requireNonNullElse(texture, Identifiers.EMPTY_IDENTIFIER);
+	}
+
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/ModelEntryData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/ModelEntryData.java
@@ -16,10 +16,13 @@ import org.jetbrains.annotations.NotNull;
 public class ModelEntryData {
 	@SerializedName(value = "target", alternate = {"predicate", "criteria", "predicates"})
 	private List<JsonElement> predicates;
+
 	@Nullable
 	private String template;
+
 	@Nullable
 	private String palette;
+
 	@Builder.Default
 	@Nullable
 	private List<Float> offset = Collections.emptyList();
@@ -28,16 +31,23 @@ public class ModelEntryData {
 	@Nullable
 	private Integer resolution = 16;
 
+	@Builder.Default
+	@Nullable
+	@SerializedName(value = "children", alternate = {"textures"})
+	private List<ModelData> children = Collections.emptyList();
+
+	@Builder.Default
+	@Nullable
+	private String texture =  Identifiers.EMPTY_IDENTIFIER;
+
 	@NotNull
 	public List<Float> getOffset() {
 		return Objects.requireNonNullElse(offset, Collections.emptyList());
-
 	}
 
 	@NotNull
 	public Integer getResolution() {
 		return Objects.requireNonNullElse(resolution, 16);
-
 	}
 
 	@NotNull
@@ -53,5 +63,15 @@ public class ModelEntryData {
 	@NotNull
 	public String getPalette() {
 		return Objects.requireNonNullElse(palette, Identifiers.EMPTY_IDENTIFIER);
+	}
+
+	@NotNull
+	public List<ModelData> getChildren() {
+		return Objects.requireNonNullElse(children, Collections.emptyList());
+	}
+
+	@NotNull
+	public String getTexture() {
+		return Objects.requireNonNullElse(texture, Identifiers.EMPTY_IDENTIFIER);
 	}
 }


### PR DESCRIPTION
This PR introduces support for adding static textures to generated models, either in the base model file, or in any model variant. Textures can be placed into a list, and will also work with offsets.

Example:
This is an extremely dumb example, but it shows how static textures can be added to dynamically generated models. This will overlay a pickaxe over the sword blade, but it can be any texture, including animated ones.
```
 {
      "name": "sword_blade",
      "template": "sword_blade.png",
      "type": "GENERATE",
      "palette": "TOOL_MATERIAL",
      "order": 20,
      "children": [
        {
          "texture": "minecraft:item/iron_pickaxe",
          "order": 21
        }
      ],
      "variants": [
        {
          "predicate": ["name:oak"],
          "children": [
            {
              "texture": "minecraft:item/diamond_pickaxe",
              "order": 22
            }
          ]
        }
      ]
    },
```

This pr superseeds: #623 
Closes #621