### PR TITLE
[Feature]: Resource overrides from Datapacks

### DIFF
--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade.json
@@ -56,14 +56,6 @@
         "context": "COMPOSITE",
         "operation": "MULTIPLICATION",
         "value": 1
-      },
-      {
-        "id": "schematic-attack_damage-composite",
-        "type": "ATTACK_DAMAGE",
-        "order": "BASE",
-        "context": "COMPOSITE",
-        "operation": "MULTIPLICATION",
-        "value": 1
       }
     ],
     "features": [

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade.json
@@ -58,15 +58,12 @@
         "value": 1
       },
       {
-        "id": "magnetic-power-test",
-        "type": "forgero:magnetic_power",
+        "id": "schematic-attack_damage-composite",
+        "type": "ATTACK_DAMAGE",
+        "order": "BASE",
+        "context": "COMPOSITE",
+        "operation": "MULTIPLICATION",
         "value": 1
-      },
-      {
-        "id": "magnetic-range-test",
-        "type": "forgero:magnetic_range",
-        "value": 2,
-        "operation": "MULTIPLICATION"
       }
     ],
     "features": [

--- a/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade_base.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade_base.json
@@ -26,12 +26,12 @@
             "value": 1
           },
           {
-            "id": "schematic-attack_speed-composite",
+            "id": "schematic-attack_speed-composite_multiplier",
             "type": "ATTACK_SPEED",
             "value": 1
           },
           {
-            "id": "schematic-attack_damage-composite",
+            "id": "schematic-attack_damage-composite_multiplier",
             "type": "ATTACK_DAMAGE",
             "value": 1
           },

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPostInit.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPostInit.java
@@ -224,7 +224,7 @@ public class ForgeroPostInit implements ForgeroInitializedEntryPoint {
 	}
 
 	/**
-	 * The registerDataReloadListener method registers a reload listener for data the data pipeline to reload the Foregero pack configuration to update states.
+	 * The registerDataReloadListener method registers a reload listener for data the data pipeline to reload the Forgero pack configuration to update states.
 	 */
 	private void registerDataReloadListener() {
 		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(new DataPipeLineReloader());

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPreInit.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPreInit.java
@@ -90,14 +90,12 @@ import com.sigmundgranaas.forgero.minecraft.common.match.predicate.RandomPredica
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.WeatherPredicate;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.v2.PredicateWriterFactory;
 
-import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 
-import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
 

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/datareloader/ResourceManagerJsonLoader.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/datareloader/ResourceManagerJsonLoader.java
@@ -1,0 +1,66 @@
+package com.sigmundgranaas.forgero.fabric.initialization.datareloader;
+
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
+import com.sigmundgranaas.forgero.core.Forgero;
+import com.sigmundgranaas.forgero.core.context.Context;
+import com.sigmundgranaas.forgero.core.resource.data.PropertyPojo;
+import com.sigmundgranaas.forgero.core.resource.data.deserializer.AttributeGroupDeserializer;
+import com.sigmundgranaas.forgero.core.resource.data.deserializer.ContextDeserializer;
+import com.sigmundgranaas.forgero.core.resource.data.v2.data.DependencyData;
+
+import net.minecraft.resource.Resource;
+import net.minecraft.resource.ResourceManager;
+
+public class ResourceManagerJsonLoader<T> {
+
+	private final ResourceManager resourceManager;
+	private final Class<T> clazz;
+	private final String path;
+
+	public ResourceManagerJsonLoader(ResourceManager resourceManager, Class<T> clazz, String path) {
+		this.resourceManager = resourceManager;
+		this.clazz = clazz;
+		this.path = path;
+	}
+
+	private Collection<Resource> loadJsonData(String path) {
+		return resourceManager.findResources(path, p -> p.getPath().endsWith(".json")).values();
+	}
+
+	private Stream<T> streamElements() {
+		return loadJsonData(path)
+				.stream()
+				.map(this::tryParse)
+				.flatMap(Optional::stream);
+	}
+
+	public List<T> load() {
+		return streamElements()
+				.collect(Collectors.toList());
+	}
+
+	private Optional<T> tryParse(Resource resource) {
+		try (var stream = resource.getInputStream()){
+			GsonBuilder builder = new GsonBuilder();
+			builder.registerTypeAdapter(DependencyData.class, new DependencyData.DependencyDataDeserializer());
+			builder.registerTypeAdapter(new TypeToken<List<PropertyPojo.Attribute>>() {
+			}.getType(), new AttributeGroupDeserializer());
+			builder.registerTypeAdapter(new TypeToken<Context>() {
+			}.getType(), new ContextDeserializer());
+			T element = builder.create().fromJson(new JsonReader(new InputStreamReader(stream)), this.clazz);
+			return Optional.of(element);
+		} catch (Exception e) {
+			Forgero.LOGGER.error(e);
+			return Optional.empty();
+		}
+	}
+}

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/resources/FabricPackFinder.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/resources/FabricPackFinder.java
@@ -33,5 +33,4 @@ public class FabricPackFinder implements PackageSupplier {
 
 		return resources.stream().map(CompletableFuture::join).toList();
 	}
-
 }

--- a/fabric/modules/generator/src/main/java/com/sigmundgranaas/forgero/generator/GeneratorInitializer.java
+++ b/fabric/modules/generator/src/main/java/com/sigmundgranaas/forgero/generator/GeneratorInitializer.java
@@ -31,6 +31,5 @@ public class GeneratorInitializer implements ModInitializer {
 		Function<Item, String> identifier = item -> Registries.ITEM.getId(item).toString();
 		operation("minecraft:identifier", "identifier", itemOperationFactory.build(identifier));
 		operation("minecraft:identifier", "id", itemOperationFactory.build(identifier));
-
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/registry/impl/ReloadableStateRegistry.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/registry/impl/ReloadableStateRegistry.java
@@ -88,7 +88,9 @@ public class ReloadableStateRegistry implements IdentifiableRegistry<State>, Sta
 	@NotNull
 	@Synchronized
 	public Collection<StateProvider> register(Collection<State> state) {
-		return state.stream().map(this::register).collect(ImmutableList.toImmutableList());
+		return state.stream()
+				.map(this::register)
+				.collect(ImmutableList.toImmutableList());
 	}
 
 	@Synchronized

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/PipelineBuilder.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/PipelineBuilder.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import com.sigmundgranaas.forgero.core.configuration.ForgeroConfiguration;
+import com.sigmundgranaas.forgero.core.resource.data.v2.DataOverrideSupplier;
 import com.sigmundgranaas.forgero.core.resource.data.v2.DataPackage;
 import com.sigmundgranaas.forgero.core.resource.data.v2.PackageSupplier;
 import com.sigmundgranaas.forgero.core.resource.data.v2.data.DataResource;
@@ -17,6 +18,7 @@ import com.sigmundgranaas.forgero.core.state.State;
 public class PipelineBuilder {
 
 	private final List<DataPackage> packages = new ArrayList<>();
+	private final List<DataResource> overrides = new ArrayList<>();
 
 	private final Set<String> dependencies = new HashSet<>();
 	private final List<ResourceListener<List<DataResource>>> dataListeners = new ArrayList<>();
@@ -24,8 +26,9 @@ public class PipelineBuilder {
 	private final List<ResourceListener<Map<String, State>>> stateListener = new ArrayList<>();
 	private final List<ResourceListener<List<RecipeData>>> recipeListener = new ArrayList<>();
 	private final List<ResourceListener<List<String>>> createStateListener = new ArrayList<>();
-	private boolean silent = false;
 	private Supplier<ForgeroConfiguration> configProvider = ForgeroConfiguration::new;
+	private boolean silent = false;
+
 
 	public static PipelineBuilder builder() {
 		return new PipelineBuilder();
@@ -67,6 +70,12 @@ public class PipelineBuilder {
 		return this;
 	}
 
+	public PipelineBuilder register(DataOverrideSupplier supplier) {
+		var overrides = supplier.get();
+		this.overrides.addAll(overrides);
+		return this;
+	}
+
 	public PipelineBuilder register(Supplier<ForgeroConfiguration> config) {
 		this.configProvider = config;
 		return this;
@@ -83,6 +92,6 @@ public class PipelineBuilder {
 	}
 
 	public ResourcePipeline build() {
-		return new ResourcePipeline(packages, dataListeners, stateListener, inflatedDataListener, recipeListener, createStateListener, configProvider.get(), dependencies, silent);
+		return new ResourcePipeline(packages, overrides, dataListeners, stateListener, inflatedDataListener, recipeListener, createStateListener, configProvider.get(), dependencies, silent);
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/ResourcePipeline.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/ResourcePipeline.java
@@ -24,6 +24,7 @@ import com.sigmundgranaas.forgero.core.type.TypeTree;
 
 public class ResourcePipeline {
 	private final List<DataPackage> packages;
+	private final List<DataResource> overrides;
 	private final List<ResourceListener<List<DataResource>>> dataListeners;
 	private final List<ResourceListener<List<DataResource>>> inflatedDataListener;
 	private final List<ResourceListener<Map<String, State>>> stateListener;
@@ -37,8 +38,9 @@ public class ResourcePipeline {
 	private TypeTree tree;
 	private List<RecipeData> recipes;
 
-	public ResourcePipeline(List<DataPackage> packages, List<ResourceListener<List<DataResource>>> dataListeners, List<ResourceListener<Map<String, State>>> stateListener, List<ResourceListener<List<DataResource>>> inflatedDataListener, List<ResourceListener<List<RecipeData>>> recipeListener, List<ResourceListener<List<String>>> createStateListener, ForgeroConfiguration configuration, Set<String> modDependencies, boolean silent) {
+	public ResourcePipeline(List<DataPackage> packages, List<DataResource> overrides, List<ResourceListener<List<DataResource>>> dataListeners, List<ResourceListener<Map<String, State>>> stateListener, List<ResourceListener<List<DataResource>>> inflatedDataListener, List<ResourceListener<List<RecipeData>>> recipeListener, List<ResourceListener<List<String>>> createStateListener, ForgeroConfiguration configuration, Set<String> modDependencies, boolean silent) {
 		this.packages = packages;
+		this.overrides = overrides;
 		this.dataListeners = dataListeners;
 		this.inflatedDataListener = inflatedDataListener;
 		this.stateListener = stateListener;
@@ -91,7 +93,7 @@ public class ResourcePipeline {
 		List<DataResource> validatedResources = validateResources(validatedPackages);
 
 		tree = assembleTypeTree(validatedResources);
-		var dataBuilder = DataBuilder.of(validatedResources, tree);
+		var dataBuilder = DataBuilder.of(validatedResources, overrides, tree);
 		List<DataResource> resources = dataBuilder.buildResources();
 		this.recipes = dataBuilder.recipes();
 

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/DataBuilder.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/DataBuilder.java
@@ -71,6 +71,7 @@ public class DataBuilder {
 		Map<String, DataResource> namedResources = resources.stream()
 				.map(res -> applyOverride(this.mappedOverrides, res))
 				.collect(Collectors.toMap((DataResource::name), (dataResource -> dataResource), (present, newRes) -> newRes));
+
 		namedResources.remove(Identifiers.EMPTY_IDENTIFIER);
 		this.resources = namedResources.values().stream()
 				.map(res -> applyParent(namedResources, res))

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/DataOverrideSupplier.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/DataOverrideSupplier.java
@@ -1,0 +1,14 @@
+package com.sigmundgranaas.forgero.core.resource.data.v2;
+
+
+import com.sigmundgranaas.forgero.core.resource.data.v2.data.DataResource;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+@FunctionalInterface
+public interface DataOverrideSupplier extends Supplier<List<DataResource>>{
+	static DataOverrideSupplier of(List<DataResource> res){
+		return () -> res;
+	}
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DataResource.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DataResource.java
@@ -120,16 +120,26 @@ public class DataResource implements Identifiable {
 	private static List<PropertyPojo.Attribute> mergeNonNullAttributeLists(List<PropertyPojo.Attribute> firstList,
 	                                                                       List<PropertyPojo.Attribute> secondList) {
 		var combinedAttributes = new HashMap<String, PropertyPojo.Attribute>();
+		var others = new ArrayList<PropertyPojo.Attribute>();
 
 		for (PropertyPojo.Attribute attr : firstList) {
-			combinedAttributes.put(attr.id, attr);
+			if(!attr.id.equals(EMPTY_IDENTIFIER)){
+				combinedAttributes.put(attr.id, attr);
+			}else{
+				others.add(attr);
+			}
 		}
 
 		for (PropertyPojo.Attribute attr : secondList) {
-			combinedAttributes.merge(attr.id, attr, DataResource::attributeMergeRule);
+			if(!attr.id.equals(EMPTY_IDENTIFIER)){
+				combinedAttributes.merge(attr.id, attr, DataResource::attributeMergeRule);
+			}else{
+				others.add(attr);
+			}
 		}
 
-		return new ArrayList<>(combinedAttributes.values());
+		others.addAll(combinedAttributes.values());
+		return others;
 	}
 
 	/**

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DataResource.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/DataResource.java
@@ -2,6 +2,7 @@ package com.sigmundgranaas.forgero.core.resource.data.v2.data;
 
 import static com.sigmundgranaas.forgero.core.util.Identifiers.EMPTY_IDENTIFIER;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -97,13 +98,82 @@ public class DataResource implements Identifiable {
 		} else return Objects.requireNonNullElse(attribute1, attribute2);
 	}
 
-	public static List<PropertyPojo.Attribute> mergeAttributes(List<PropertyPojo.Attribute> attribute1, List<PropertyPojo.Attribute> attribute2) {
-		if (attribute1 == null && attribute2 == null)
+	/**
+	 * Merges two lists of {@link PropertyPojo.Attribute}, considering both id and order.
+	 * If two attributes have the same id but different priority, the one with the higher priority is kept.
+	 *
+	 * @param first the first list of attributes to merge.
+	 * @param second the second list of attributes to merge.
+	 * @return a merged list of attributes, with duplicates removed based on id and higher order preference.
+	 */
+	public static List<PropertyPojo.Attribute> mergeAttributes(List<PropertyPojo.Attribute> first,
+	                                                           List<PropertyPojo.Attribute> second) {
+		if (areAllListsNull(first, second)) {
 			return Collections.emptyList();
-		else if (attribute1 != null && attribute2 != null) {
-			var filteredMergedAttributes = attribute2.stream().filter(attr -> !attr.id.equals(EMPTY_IDENTIFIER) && attribute1.stream().noneMatch(attribute -> attribute.id.equals(attr.id))).toList();
-			return Stream.of(attribute1, filteredMergedAttributes).flatMap(List::stream).toList();
-		} else return Objects.requireNonNullElse(attribute1, attribute2);
+		} else if (areNoListsNull(first, second)) {
+			return mergeNonNullAttributeLists(first, second);
+		} else {
+			return Objects.requireNonNullElse(first, second);
+		}
+	}
+
+	private static List<PropertyPojo.Attribute> mergeNonNullAttributeLists(List<PropertyPojo.Attribute> firstList,
+	                                                                       List<PropertyPojo.Attribute> secondList) {
+		var combinedAttributes = new HashMap<String, PropertyPojo.Attribute>();
+
+		for (PropertyPojo.Attribute attr : firstList) {
+			combinedAttributes.put(attr.id, attr);
+		}
+
+		for (PropertyPojo.Attribute attr : secondList) {
+			combinedAttributes.merge(attr.id, attr, DataResource::attributeMergeRule);
+		}
+
+		return new ArrayList<>(combinedAttributes.values());
+	}
+
+	/**
+	 * Merges two attributes, considering both id and order.
+	 * @param existingAttr the attribute that already exists.
+	 * @param newAttr the attribute that is being merged.
+	 * @return the attribute with the highest priority.
+	 */
+	private static PropertyPojo.Attribute attributeMergeRule(PropertyPojo.Attribute existingAttr, PropertyPojo.Attribute newAttr) {
+		if (newAttr.priority > existingAttr.priority && newAttr.id.equals(existingAttr.id)) {
+			return newAttr;
+		} else {
+			return existingAttr;
+		}
+	}
+
+	/**
+	 * Checks if all provided lists are null.
+	 *
+	 * @param lists an array of lists to check for null.
+	 * @return true if all lists are null, false otherwise.
+	 */
+	private static boolean areAllListsNull(List<?>... lists) {
+		for (List<?> list : lists) {
+			if (list != null) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Checks if none of the provided lists are null.
+	 *
+	 * @param lists an array of lists to check for non-null.
+	 * @return true if none of the lists are null, false otherwise.
+	 */
+	private static boolean areNoListsNull(List<?>... lists) {
+		for (List<?> list : lists) {
+			if (list == null) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@NotNull

--- a/forgero-core/src/test/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade.json
+++ b/forgero-core/src/test/resources/data/forgero/packs/forgero-vanilla/schematic/sword_blade.json
@@ -71,17 +71,6 @@
         "context": "COMPOSITE",
         "operation": "MULTIPLICATION",
         "value": 1
-      },
-      {
-        "id": "magnetic-power-test",
-        "type": "forgero:magnetic_power",
-        "value": 1
-      },
-      {
-        "id": "magnetic-range-test",
-        "type": "forgero:magnetic_range",
-        "value": 2,
-        "operation": "MULTIPLICATION"
       }
     ],
     "features": [


### PR DESCRIPTION
Added support for loading resource overrides from datapacks. Currently only supports attributes and features. This works both when loading data packs via mods, and custom datapacks placed in the world folder.

Place resource overrides in: `data/<namespace>/resource_override/`. It is important to specify the name and namespace of the resource you are overriding. When overriding based on attribute id, you need to specify the priority of this attribute. By default it is set to 0.

Examples:
`oak.json`
```
{
  "name": "oak",
  "namespace": "minecraft",
  "priority": 6,
  "properties": {
    "attributes": [
      {
        "id": "forgero-new-attribute-durability",
        "type": "DURABILITY",
        "context": "COMPOSITE",
        "value": 100
      },
      {
        "id": "wood-attack_damage-composite",
        "type": "ATTACK_DAMAGE",
        "value": 5,
        "context": "COMPOSITE",
        "order": "BASE",
        "operation": "ADDITION",
        "priority": 5
      }
    ]
  }
}

```

`wood_base.json`

```
{
  "name": "wood_base",
  "namespace": "minecraft",
  "priority": 6,
  "properties": {
    "attributes": [
      {
        "id": "wood-attack_damage-composite",
        "type": "ATTACK_DAMAGE",
        "value": 10,
        "context": "COMPOSITE",
        "order": "BASE",
        "operation": "ADDITION",
        "priority": 1
      }
    ],
    "features": [
      {
        "type": "minecraft:block_breaking",
        "selector": {
          "type": "forgero:single"
        },
        "speed": "forgero:instant",
        "predicate": {
          "type": "forgero:random",
          "seed": ["world_time", "block_pos"],
          "value": 0.5
        },
        "title": "feature.forgero.random_insta_break.title",
        "description": "feature.forgero.random_insta_break.description"
      }
    ]
  }
}

```
