### PR TITLE
[Feature]: A context type checking predicate

### DIFF
--- a/content/forgero-extended/src/main/resources/data/forgero/packs/vein_mining_schematics/schematic/ore_miner_pickaxe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/vein_mining_schematics/schematic/ore_miner_pickaxe_head.json
@@ -75,12 +75,23 @@
       {
         "type": "minecraft:block_breaking",
         "selector": {
-          "type": "forgero:single"
+          "type": "forgero:radius",
+          "filter": [
+            "forgero:can_mine",
+            {
+              "type": "minecraft:block",
+              "tag": "forgero:vein_mining_ores"
+            }
+          ],
+          "depth": 1
         },
-        "speed": "forgero:instant",
-        "predicate":{"type": "forgero:context_type", "types": ["PICKAXE_HEAD"] },
-        "title": "feature.forgero.random_insta_break.title",
-        "description": "feature.forgero.random_insta_break.description"
+        "speed": "forgero:all",
+        "predicate": {
+          "type": "minecraft:block",
+          "tag": "forgero:vein_mining_ores"
+        },
+        "title": "feature.forgero.vein_mining.title",
+        "description": "feature.forgero.ore_vein_mining.description"
       }
     ]
   },

--- a/content/forgero-extended/src/main/resources/data/forgero/packs/vein_mining_schematics/schematic/ore_miner_pickaxe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/packs/vein_mining_schematics/schematic/ore_miner_pickaxe_head.json
@@ -75,23 +75,12 @@
       {
         "type": "minecraft:block_breaking",
         "selector": {
-          "type": "forgero:radius",
-          "filter": [
-            "forgero:can_mine",
-            {
-              "type": "minecraft:block",
-              "tag": "forgero:vein_mining_ores"
-            }
-          ],
-          "depth": 1
+          "type": "forgero:single"
         },
-        "speed": "forgero:all",
-        "predicate": {
-          "type": "minecraft:block",
-          "tag": "forgero:vein_mining_ores"
-        },
-        "title": "feature.forgero.vein_mining.title",
-        "description": "feature.forgero.ore_vein_mining.description"
+        "speed": "forgero:instant",
+        "predicate":{"type": "forgero:context_type", "types": ["PICKAXE_HEAD"] },
+        "title": "feature.forgero.random_insta_break.title",
+        "description": "feature.forgero.random_insta_break.description"
       }
     ]
   },

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPreInit.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPreInit.java
@@ -86,6 +86,7 @@ import com.sigmundgranaas.forgero.minecraft.common.item.tool.DynamicWeaponItemRe
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.BlockPredicateMatcher;
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.DamagePercentagePredicate;
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.EntityPredicateMatcher;
+import com.sigmundgranaas.forgero.minecraft.common.match.predicate.MatchContextTypePredicate;
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.RandomPredicate;
 import com.sigmundgranaas.forgero.minecraft.common.match.predicate.WeatherPredicate;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.v2.PredicateWriterFactory;
@@ -150,6 +151,7 @@ public class ForgeroPreInit implements ForgeroPreInitializationEntryPoint {
 		PredicateFactory.register(WeatherPredicate.WeatherPredicateBuilder::new);
 		PredicateFactory.register(CanMineFilter.CanMineFilterBuilder::new);
 		PredicateFactory.register(RandomPredicate.RandomPredicatePredicateBuilder::new);
+		PredicateFactory.register(MatchContextTypePredicate.MatchContextTypePredicateBuilder::new);
 
 		//Writers
 		PredicateWriterFactory.register(EntityPredicateMatcher.EntityPredicateWriter::builder);

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/feature/FeatureUtils.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/feature/FeatureUtils.java
@@ -22,19 +22,27 @@ import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 
 public class FeatureUtils {
-	public static <T extends Feature> List<T> cachedFeatures(ItemStack stack, ClassKey<T> key) {
+	public static <T extends Feature> List<T> cachedRootFeatures(ItemStack stack, ClassKey<T> key) {
 		var state = StateService.INSTANCE.convert(stack);
 		if (state.isEmpty() || !FeatureCache.check(key, state.get())) {
 			return Collections.emptyList();
 		}
 
-		return FeatureCache.get(key, state.get());
+		return FeatureCache.getRootFeatures(key, state.get());
+	}
+
+	public static <T extends Feature> List<T> appliedCachedFeatures(ItemStack stack, MatchContext context, ClassKey<T> key) {
+		var state = StateService.INSTANCE.convert(stack);
+		if (state.isEmpty() || !FeatureCache.check(key, state.get())) {
+			return Collections.emptyList();
+		}
+
+		return FeatureCache.apply(key, state.get(), context);
 	}
 
 	public static <T extends Feature> List<T> cachedFilteredFeatures(ItemStack stack, ClassKey<T> key, MatchContext context) {
-		return cachedFeatures(stack, key)
+		return appliedCachedFeatures(stack, context, key)
 				.stream()
-				.filter(feat -> feat.applyCondition(Matchable.DEFAULT_TRUE, context))
 				.toList();
 	}
 
@@ -45,7 +53,7 @@ public class FeatureUtils {
 			return Optional.empty();
 		}
 
-		return FeatureCache.get(key, state.get())
+		return FeatureCache.getRootFeatures(key, state.get())
 				.stream()
 				.findFirst();
 	}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/match/predicate/MatchContextTypePredicate.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/match/predicate/MatchContextTypePredicate.java
@@ -1,0 +1,54 @@
+package com.sigmundgranaas.forgero.minecraft.common.match.predicate;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.sigmundgranaas.forgero.core.model.match.builders.ElementParser;
+import com.sigmundgranaas.forgero.core.model.match.builders.PredicateBuilder;
+import com.sigmundgranaas.forgero.core.type.Type;
+import com.sigmundgranaas.forgero.core.util.match.MatchContext;
+import com.sigmundgranaas.forgero.core.util.match.Matchable;
+
+import net.minecraft.util.JsonSerializer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+public class MatchContextTypePredicate implements Matchable {
+	public static String ID = "forgero:context_type";
+
+	final List<Type> types;
+
+	MatchContextTypePredicate(List<Type> types) {
+		this.types = types;
+	}
+
+	public boolean test(Matchable target, MatchContext context) {
+		return types.stream().allMatch(type -> context.test(type, MatchContext.of()));
+	}
+
+	public static class Serializer implements JsonSerializer<MatchContextTypePredicate> {
+		public void toJson(JsonObject jsonObject, MatchContextTypePredicate matchContextTypePredicate, JsonSerializationContext jsonSerializationContext) {
+
+		}
+
+		public MatchContextTypePredicate fromJson(JsonObject jsonObject, JsonDeserializationContext jsonDeserializationContext) {
+			List<Type> types = StreamSupport.stream(jsonObject.getAsJsonArray("types").spliterator(), false)
+					.map(JsonElement::getAsString)
+					.map(Type::of)
+					.toList();
+			return new MatchContextTypePredicate(types);
+		}
+	}
+
+	public static class MatchContextTypePredicateBuilder implements PredicateBuilder {
+		@Override
+		public Optional<Matchable> create(JsonElement element) {
+			return ElementParser.fromIdentifiedElement(element, ID)
+					.map(json -> new MatchContextTypePredicate.Serializer().fromJson(json, null));
+		}
+	}
+}
+

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/match/builders/string/StringTypeBuilder.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/match/builders/string/StringTypeBuilder.java
@@ -15,10 +15,17 @@ import com.sigmundgranaas.forgero.core.util.match.Matchable;
 public class StringTypeBuilder implements PredicateBuilder {
 	@Override
 	public Optional<Matchable> create(JsonElement element) {
-		return ElementParser.fromString(element)
-				.filter(string -> string.contains("type:"))
-				.map(string -> string.replace("type:", ""))
-				.map(Type::of)
-				.map(TypePredicate::new);
+		if(element.isJsonObject()){
+			return ElementParser.fromIdentifiedElement(element, "forgero:type")
+					.map(jsonObject -> jsonObject.get("value").getAsString())
+					.map(Type::of)
+					.map(TypePredicate::new);
+		}else{
+			return ElementParser.fromString(element)
+					.filter(string -> string.contains("type:"))
+					.map(string -> string.replace("type:", ""))
+					.map(Type::of)
+					.map(TypePredicate::new);
+		}
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/match/predicate/TypePredicate.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/match/predicate/TypePredicate.java
@@ -15,6 +15,9 @@ public record TypePredicate(Type type) implements Matchable {
 		if (match instanceof FilledSlot slot && slot.content().test(type)) {
 			return true;
 		}
+
+		// Note: The match is very often a TRUE lambda, so the context test really will never actually have anything to do here.
+		// Does that break a lot???
 		return match.test(type, context) || context.test(type, MatchContext.of());
 	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/ConstructedComposite.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/ConstructedComposite.java
@@ -74,7 +74,7 @@ public class ConstructedComposite extends BaseComposite implements ConstructedSt
 		var props = new ArrayList<>(super.compositeProperties(target, context));
 
 		var partProps = parts().stream()
-				.flatMap(part -> part.getRootProperties(target, context).stream().map(part::applySource))
+				.flatMap(part -> part.applyProperty(target, context).stream().map(part::applySource))
 				.toList();
 
 		props.addAll(propertyProcessor.process(partProps, target, context));


### PR DESCRIPTION
Adds a predicate that can match the current context match for types. This can be used to set predicates for features that should only apply when some types are present on the construct.

Example that will only apply when on a pickaxe head. This can be used on materials so it does not apply when used on handles.
```
 {
        "type": "minecraft:block_breaking",
        "selector": {
          "type": "forgero:single"
        },
        "speed": "forgero:instant",
        "predicate":{"type": "forgero:context_type", "types": ["PICKAXE_HEAD"] },
        "title": "feature.forgero.random_insta_break.title",
        "description": "feature.forgero.random_insta_break.description"
      }
```