### PR TITLE
[Patch]: Corrected namespace for compat packs

### DIFF
--- a/content/forgero-compat/src/main/resources/data/forgero/packs/betternether/default.json
+++ b/content/forgero-compat/src/main/resources/data/forgero/packs/betternether/default.json
@@ -1,5 +1,5 @@
 {
-  "namespace": "forgero",
+  "namespace": "betternether",
   "dependencies": [
     "minecraft",
     "forgero",

--- a/content/forgero-compat/src/main/resources/data/forgero/packs/byg/default.json
+++ b/content/forgero-compat/src/main/resources/data/forgero/packs/byg/default.json
@@ -1,5 +1,5 @@
 {
-  "namespace": "forgero",
+  "namespace": "byg",
   "dependencies": [
     "minecraft",
     "forgero",

--- a/fabric/forgero-fabric-compat/build.gradle
+++ b/fabric/forgero-fabric-compat/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 	//modImplementation "maven.modrinth:cloth-config:9.0.94+fabric"
 	//modImplementation("dev.kosmx.player-anim:player-animation-lib-fabric:${project.player_anim_version}")
 
-	//betterend&betternether
+	// Betterend & Betternether
 	// modImplementation "maven.modrinth:BgNRHReB:mKksn4EY"
 	// modImplementation "maven.modrinth:gc8OEnCC:5CIFclEA"
 	// modImplementation "maven.modrinth:MpzVLzy5:InVK1xFf"


### PR DESCRIPTION
Corrects the namespace for the compat packs: Betternether and byg. This was causing the wrong recipes to be generated.

Closes #831 