### PR TITLE
[patch]: Fixing recipe codecs for 1.20.4

### DIFF
--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/recipe/customrecipe/CodecUtils.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/recipe/customrecipe/CodecUtils.java
@@ -1,0 +1,36 @@
+package com.sigmundgranaas.forgero.minecraft.common.recipe.customrecipe;
+
+import com.mojang.serialization.*;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class CodecUtils {
+	public static <T, R> Codec<R> extendCodec(Codec<T> baseCodec, Function<T, R> toExtendedType, Function<R, T> toBaseType) {
+		if (baseCodec instanceof MapCodec.MapCodecCodec) {
+			MapCodec<T> baseMapCodec = ((MapCodec.MapCodecCodec<T>) baseCodec).codec();
+
+			MapCodec<R> extendedMapCodec = new MapCodec<>() {
+				@Override
+				public <T2> Stream<T2> keys(DynamicOps<T2> ops) {
+					return baseMapCodec.keys(ops);
+				}
+
+				@Override
+				public <T2> RecordBuilder<T2> encode(R extendedType, DynamicOps<T2> ops, RecordBuilder<T2> builder) {
+					T baseType = toBaseType.apply(extendedType);
+					return baseMapCodec.encode(baseType, ops, builder);
+				}
+
+				@Override
+				public <T2> DataResult<R> decode(DynamicOps<T2> ops, MapLike<T2> map) {
+					return baseMapCodec.decode(ops, map).map(toExtendedType);
+				}
+			};
+
+			return new MapCodec.MapCodecCodec<>(extendedMapCodec);
+		} else {
+			return baseCodec.xmap(toExtendedType, toBaseType);
+		}
+	}
+}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/recipe/customrecipe/RepairKitRecipe.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/recipe/customrecipe/RepairKitRecipe.java
@@ -82,9 +82,7 @@ public class RepairKitRecipe extends ShapelessRecipe {
 		private final ShapelessRecipe.Serializer rootSerializer = new ShapelessRecipe.Serializer();
 		@Override
 		public Codec<RepairKitRecipe> codec() {
-			return rootSerializer.codec().flatXmap(recipe -> DataResult.success(new RepairKitRecipe(recipe, StateService.INSTANCE)) ,(recipe) -> {
-				throw new NotImplementedException("Serializing ShapedRecipe is not implemented yet.");
-			} );
+			return CodecUtils.extendCodec(rootSerializer.codec(), (recipe) -> new RepairKitRecipe(recipe, StateService.INSTANCE), recipe -> recipe);
 		}
 
 		public static final RepairKitRecipeSerializer INSTANCE = new RepairKitRecipeSerializer();

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/recipe/customrecipe/SchematicPartRecipe.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/recipe/customrecipe/SchematicPartRecipe.java
@@ -3,10 +3,12 @@ package com.sigmundgranaas.forgero.minecraft.common.recipe.customrecipe;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import com.google.gson.JsonObject;
-import com.mojang.serialization.Codec;
-import com.mojang.serialization.DataResult;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.*;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.sigmundgranaas.forgero.core.Forgero;
 import com.sigmundgranaas.forgero.core.state.State;
 import com.sigmundgranaas.forgero.core.state.Upgradeable;
@@ -30,7 +32,7 @@ public class SchematicPartRecipe extends ShapelessRecipe {
 	private final StateService service;
 
 	public SchematicPartRecipe(ShapelessRecipe recipe, StateService service) {
-		super( recipe.getGroup(),recipe.getCategory(), recipe.getResult(null), recipe.getIngredients());
+		super(recipe.getGroup(), recipe.getCategory(), recipe.getResult(null), recipe.getIngredients());
 		this.service = service;
 	}
 
@@ -68,18 +70,18 @@ public class SchematicPartRecipe extends ShapelessRecipe {
 	}
 
 	@Override
-	public RecipeSerializer<?> getSerializer() {
+	public RecipeSerializer<SchematicPartRecipe> getSerializer() {
 		return SchematicPartRecipeSerializer.INSTANCE;
 	}
 
 	public static class SchematicPartRecipeSerializer implements RecipeSerializer<SchematicPartRecipe> , ForgeroRecipeSerializer {
 		public static final SchematicPartRecipeSerializer INSTANCE = new SchematicPartRecipeSerializer();
 		private final ShapelessRecipe.Serializer rootSerializer = new ShapelessRecipe.Serializer();
+
+
 		@Override
 		public Codec<SchematicPartRecipe> codec() {
-			return rootSerializer.codec().flatXmap(recipe -> DataResult.success(new SchematicPartRecipe(recipe, StateService.INSTANCE)) ,(recipe) -> {
-				throw new NotImplementedException("Serializing ShapedRecipe is not implemented yet.");
-			} );
+			return CodecUtils.extendCodec(rootSerializer.codec(), (recipe) -> new SchematicPartRecipe(recipe, StateService.INSTANCE), recipe -> recipe);
 		}
 
 		@Override
@@ -88,7 +90,7 @@ public class SchematicPartRecipe extends ShapelessRecipe {
 		}
 
 		@Override
-		public SchematicPartRecipe read( PacketByteBuf packetByteBuf) {
+		public SchematicPartRecipe read(PacketByteBuf packetByteBuf) {
 			return new SchematicPartRecipe(rootSerializer.read( packetByteBuf), StateService.INSTANCE);
 		}
 

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/recipe/customrecipe/StateCraftingRecipe.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/recipe/customrecipe/StateCraftingRecipe.java
@@ -156,16 +156,15 @@ public class StateCraftingRecipe extends ShapedRecipe {
 	public static class StateCraftingRecipeSerializer implements RecipeSerializer<StateCraftingRecipe> , ForgeroRecipeSerializer {
 		public static final StateCraftingRecipeSerializer INSTANCE = new StateCraftingRecipeSerializer();
 		private final ShapedRecipe.Serializer rootSerializer = new ShapedRecipe.Serializer();
+
 		@Override
 		public Codec<StateCraftingRecipe> codec() {
-			return rootSerializer.codec().flatXmap(recipe -> DataResult.success(new StateCraftingRecipe(recipe, StateService.INSTANCE)) ,(recipe) -> {
-				throw new NotImplementedException("Serializing ShapedRecipe is not implemented yet.");
-			} );
+			return CodecUtils.extendCodec(rootSerializer.codec(), (recipe) -> new StateCraftingRecipe(recipe, StateService.INSTANCE), recipe -> recipe);
 		}
 
 		@Override
 		public StateCraftingRecipe read( PacketByteBuf packetByteBuf) {
-			return new StateCraftingRecipe(rootSerializer.read( packetByteBuf), StateService.INSTANCE);
+			return new StateCraftingRecipe(rootSerializer.read(packetByteBuf), StateService.INSTANCE);
 		}
 
 		@Override


### PR DESCRIPTION
This implements a wrapper that makes it possible to extend existing codecs while maintaining them as a mapCodec.