### PR TITLE
[Patch]: Fix broken type predicates

### DIFF
--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/match/predicate/MatchContextTypePredicate.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/match/predicate/MatchContextTypePredicate.java
@@ -1,5 +1,9 @@
 package com.sigmundgranaas.forgero.minecraft.common.match.predicate;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -12,10 +16,6 @@ import com.sigmundgranaas.forgero.core.util.match.Matchable;
 
 import net.minecraft.util.JsonSerializer;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.StreamSupport;
-
 public class MatchContextTypePredicate implements Matchable {
 	public static String ID = "forgero:context_type";
 
@@ -26,6 +26,9 @@ public class MatchContextTypePredicate implements Matchable {
 	}
 
 	public boolean test(Matchable target, MatchContext context) {
+		if (types.isEmpty()) {
+			return false;
+		}
 		return types.stream().allMatch(type -> context.test(type, MatchContext.of()));
 	}
 
@@ -46,6 +49,9 @@ public class MatchContextTypePredicate implements Matchable {
 	public static class MatchContextTypePredicateBuilder implements PredicateBuilder {
 		@Override
 		public Optional<Matchable> create(JsonElement element) {
+			if (element.isJsonPrimitive() && element.getAsString().contains("context_type:")) {
+				return Optional.of(new MatchContextTypePredicate(List.of(Type.of(element.getAsString().replace("context_type:", "")))));
+			}
 			return ElementParser.fromIdentifiedElement(element, ID)
 					.map(json -> new MatchContextTypePredicate.Serializer().fromJson(json, null));
 		}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/context/Contexts.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/context/Contexts.java
@@ -3,6 +3,7 @@ package com.sigmundgranaas.forgero.core.context;
 public class Contexts {
 	public static final Context LOCAL = Context.of("LOCAL");
 	public static final Context COMPOSITE = Context.of("COMPOSITE");
+	public static final Context PredicateConverted = Context.of("PREDICATE_CONVERTED");
 	public static final Context UPGRADE = Context.of("UPGRADE");
 	public static final Context UNDEFINED = Context.of("UNDEFINED");
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/match/predicate/TypePredicate.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/match/predicate/TypePredicate.java
@@ -7,8 +7,9 @@ import com.sigmundgranaas.forgero.core.util.match.Matchable;
 
 
 /**
- * Matches if the type of a FilledSlot equals to the given type, or if the given type is found within a Matchable or a MatchContext.
+ * Matches if the type of FilledSlot equals to the given type, or if the given type is found within a Matchable or a MatchContext.
  */
+@Deprecated
 public record TypePredicate(Type type) implements Matchable {
 	@Override
 	public boolean test(Matchable match, MatchContext context) {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/property/v2/PredicateConvertedPropertyProcessor.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/property/v2/PredicateConvertedPropertyProcessor.java
@@ -1,0 +1,40 @@
+package com.sigmundgranaas.forgero.core.property.v2;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.sigmundgranaas.forgero.core.context.Contexts;
+import com.sigmundgranaas.forgero.core.property.CalculationOrder;
+import com.sigmundgranaas.forgero.core.property.NumericOperation;
+import com.sigmundgranaas.forgero.core.property.Property;
+import com.sigmundgranaas.forgero.core.property.attribute.AttributeBuilder;
+import com.sigmundgranaas.forgero.core.property.attribute.Category;
+import com.sigmundgranaas.forgero.core.util.match.MatchContext;
+import com.sigmundgranaas.forgero.core.util.match.Matchable;
+
+public class PredicateConvertedPropertyProcessor implements PropertyProcessor {
+	@Override
+	public List<Property> process(List<Property> propertyList, Matchable target, MatchContext context) {
+		return combineCompositeProperties(propertyList, target, context);
+	}
+
+	private List<Property> combineCompositeProperties(List<Property> props, Matchable target, MatchContext context) {
+		return Property.stream(props)
+				.getAttributes()
+				.filter(attribute -> attribute.getContext().test(Contexts.PredicateConverted))
+				.filter(attribute -> attribute.applyCondition(target, context))
+				.map(attribute -> {
+					var newBaseAttribute = new AttributeBuilder(attribute.getAttributeType())
+							.applyValue(attribute.getValue())
+							.applyOperation(NumericOperation.ADDITION)
+							.applyOrder(CalculationOrder.BASE)
+							.applyContext(Contexts.UNDEFINED)
+							.applyPredicate(Matchable.DEFAULT_TRUE)
+							.applyCategory(Category.PASS);
+					return newBaseAttribute.build();
+				})
+				.collect(Collectors.toList());
+	}
+
+
+}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/ConstructedComposite.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/state/composite/ConstructedComposite.java
@@ -14,6 +14,7 @@ import com.sigmundgranaas.forgero.core.property.Property;
 import com.sigmundgranaas.forgero.core.property.Target;
 import com.sigmundgranaas.forgero.core.property.attribute.TypeTarget;
 import com.sigmundgranaas.forgero.core.property.v2.CompositePropertyProcessor;
+import com.sigmundgranaas.forgero.core.property.v2.PredicateConvertedPropertyProcessor;
 import com.sigmundgranaas.forgero.core.state.Composite;
 import com.sigmundgranaas.forgero.core.state.IdentifiableContainer;
 import com.sigmundgranaas.forgero.core.state.State;
@@ -71,6 +72,8 @@ public class ConstructedComposite extends BaseComposite implements ConstructedSt
 	@Override
 	public List<Property> compositeProperties(Matchable target, MatchContext context) {
 		var propertyProcessor = new CompositePropertyProcessor();
+		var predicateProcessor = new PredicateConvertedPropertyProcessor();
+
 		var props = new ArrayList<>(super.compositeProperties(target, context));
 
 		var partProps = parts().stream()
@@ -78,6 +81,7 @@ public class ConstructedComposite extends BaseComposite implements ConstructedSt
 				.toList();
 
 		props.addAll(propertyProcessor.process(partProps, target, context));
+		props.addAll(predicateProcessor.process(partProps, target, context));
 
 		var otherProps = partProps.stream()
 				.filter(this::filterNormalProperties)


### PR DESCRIPTION
* Adds a new context for attributes that should be converted after checking if they should be applied
* Deprecates the old TypePredicate
* Fixes issues with the context_type and empty values

Example:
```
      {
        "id": "string-durability",
        "type": "DURABILITY",
        "value": 200,
        "context": "PREDICATE_CONVERTED",
        "predicate": {
          "type": "forgero:context_type",
          "types": [
            "BOW"
          ]
        }
      }
```

CLoses #843