### PR TITLE
[Feat]: Empty model seletor for disabling certain models

### DIFF
--- a/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-vanilla/models/handle.json
+++ b/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-vanilla/models/handle.json
@@ -2,6 +2,30 @@
   "type": "HANDLE",
   "models": [
     {
+      "name": "grip",
+      "variants": [
+        {
+          "target": [
+            "type:ARROW",
+            "model:arrow_shaft.png"
+          ],
+          "template": "empty_model"
+        }
+      ]
+    },
+    {
+      "name": "handle_dye",
+      "variants": [
+        {
+          "target": [
+            "type:ARROW",
+            "model:arrow_shaft.png"
+          ],
+          "template": "empty_model"
+        }
+      ]
+    },
+    {
       "name": "handle",
       "variants": [
         {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelMatcher.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelMatcher.java
@@ -4,11 +4,46 @@ import java.util.Optional;
 
 import com.sigmundgranaas.forgero.core.model.match.predicate.IdPredicate;
 import com.sigmundgranaas.forgero.core.model.match.predicate.ModelPredicate;
+import com.sigmundgranaas.forgero.core.texture.utils.Offset;
 import com.sigmundgranaas.forgero.core.util.match.MatchContext;
 import com.sigmundgranaas.forgero.core.util.match.Matchable;
 import org.jetbrains.annotations.NotNull;
 
 public interface ModelMatcher extends Comparable<ModelMatcher> {
+	ModelMatcher EMPTY_TRUE = new ModelMatcher() {
+		@Override
+		public int compareTo(@NotNull ModelMatcher o) {
+			return comparator(this, o);
+		}
+
+		@Override
+		public boolean match(Matchable state, MatchContext context) {
+			return true;
+		}
+
+		@Override
+		public Optional<ModelTemplate> get(Matchable state, ModelProvider provider, MatchContext context) {
+			return Optional.of(EMPTY_TEMPLATE);
+		}
+	};
+
+	ModelTemplate EMPTY_TEMPLATE = new ModelTemplate() {
+		@Override
+		public int order() {
+			return 0;
+		}
+
+		@Override
+		public Optional<Offset> getOffset() {
+			return Optional.empty();
+		}
+
+		@Override
+		public <T> T convert(Converter<T, ModelTemplate> converter) {
+			return converter.convert(this);
+		}
+	};
+
 	ModelMatcher EMPTY = new ModelMatcher() {
 		@Override
 		public int compareTo(@NotNull ModelMatcher o) {

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/util/Identifiers.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/util/Identifiers.java
@@ -2,6 +2,7 @@ package com.sigmundgranaas.forgero.core.util;
 
 public class Identifiers {
 	public static String EMPTY_IDENTIFIER = "EMPTY";
+	public static String EMPTY_IMAGE_IDENTIFIER = "empty_model";
 	public static String CREATE_IDENTIFIER = "CREATE";
 	public static String THIS_IDENTIFIER = "this";
 }


### PR DESCRIPTION
Adds an "empty_model" template that will make the models selector choose an empty model

Example:
```
{
      "name": "grip",
      "variants": [
        {
          "target": [
            "type:ARROW",
            "model:arrow_shaft.png"
          ],
          "template": "empty_model"
        }
      ]
    },
```