### PR TITLE
[Patch]: Fixed improper mixin plugin init for EmissiveTextures

### DIFF
--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/CompatMixinPlugin.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/mixins/CompatMixinPlugin.java
@@ -16,7 +16,7 @@ public class CompatMixinPlugin implements IMixinConfigPlugin {
 
 	private static final Map<String, Supplier<Boolean>> CONDITIONS = ImmutableMap.of(
 			"com.sigmundgranaas.forgero.fabric.mixins.BetterCombatWeaponRegistryMixin", ForgeroCompatInitializer.bettercombat,
-			"com.sigmundgranaas.forgero.fabric.mixins.EmissiveOverlayModelMixin", ForgeroCompatInitializer.bettercombat
+			"com.sigmundgranaas.forgero.fabric.mixins.EmissiveOverlayModelMixin", ForgeroCompatInitializer.emissiveModel
 
 	);
 


### PR DESCRIPTION
Fixes a crash where bettercombat is loaded but not EmissiveModeTextures