### PR TITLE
[Patch]: Disabled arrow heads from being inserted into the disassembly station

### DIFF
--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/block/assemblystation/AssemblyStationScreenHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/block/assemblystation/AssemblyStationScreenHandler.java
@@ -13,8 +13,6 @@ import net.minecraft.inventory.Inventory;
 import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
-import net.minecraft.recipe.RecipeType;
-import net.minecraft.registry.Registries;
 import net.minecraft.resource.featuretoggle.FeatureFlags;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerContext;
@@ -104,7 +102,6 @@ public class AssemblyStationScreenHandler extends ScreenHandler {
 			super.dropInventory(player, new SimpleInventory(compositeSlot.getStack()));
 		}
 	}
-
 
 
 	@Override
@@ -237,7 +234,14 @@ public class AssemblyStationScreenHandler extends ScreenHandler {
 
 		@Override
 		public boolean canInsert(ItemStack stack) {
-			return this.inventory.isEmpty() && doneConstructing && stack.getDamage() == 0 && resultInventory.isEmpty() && !(DisassemblyHandler.createHandler(stack) instanceof EmptyHandler);
+			DisassemblyHandler handler = DisassemblyHandler.createHandler(stack);
+			if (handler instanceof EmptyHandler) {
+				return false;
+			} else if (handler.disassemble().isEmpty()) {
+				return false;
+			}
+
+			return this.inventory.isEmpty() && doneConstructing && stack.getDamage() == 0 && resultInventory.isEmpty();
 		}
 
 		public void doneConstructing() {

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/block/assemblystation/state/CompositeHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/block/assemblystation/state/CompositeHandler.java
@@ -21,10 +21,10 @@ public class CompositeHandler implements DisassemblyHandler {
 
 	@Override
 	public List<ItemStack> disassemble() {
-		if (composite.test(Type.ARROW_HEAD)) {
+		if (composite.type().test(Type.ARROW_HEAD)) {
 			return Collections.emptyList();
 		}
-		if (composite.test(Type.ARROW)) {
+		if (composite.type().test(Type.ARROW)) {
 			return parts()
 					.filter(stack -> stack.getItem() != Items.FEATHER)
 					.toList();

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/block/assemblystation/state/CompositeHandler.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/block/assemblystation/state/CompositeHandler.java
@@ -1,12 +1,16 @@
 package com.sigmundgranaas.forgero.minecraft.common.block.assemblystation.state;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import com.sigmundgranaas.forgero.core.state.Composite;
+import com.sigmundgranaas.forgero.core.type.Type;
 import com.sigmundgranaas.forgero.minecraft.common.service.StateService;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 
 public class CompositeHandler implements DisassemblyHandler {
 	private final Composite composite;
@@ -17,29 +21,27 @@ public class CompositeHandler implements DisassemblyHandler {
 
 	@Override
 	public List<ItemStack> disassemble() {
+		if (composite.test(Type.ARROW_HEAD)) {
+			return Collections.emptyList();
+		}
+		if (composite.test(Type.ARROW)) {
+			return parts()
+					.filter(stack -> stack.getItem() != Items.FEATHER)
+					.toList();
+		}
+		return parts().toList();
+	}
+
+	private Stream<ItemStack> parts() {
 		return composite.components().stream()
 				.filter(state -> !state.identifier().contains("schematic"))
 				.map(StateService.INSTANCE::convert)
-				.flatMap(Optional::stream)
-				.toList();
+				.flatMap(Optional::stream);
 	}
 
-	public boolean isDisassembled(List<ItemStack> stacks) {
-		var compared = disassemble();
-		if (compared.size() != stacks.size()) {
-			return false;
-		}
-		for (int i = 0; i < stacks.size(); i++) {
-			if (!stacks.get(i).isOf(compared.get(i).getItem())) {
-				return false;
-			}
-		}
-		return true;
-	}
 
 	@Override
 	public DisassemblyHandler insertIntoDisassemblySlot(ItemStack stack) {
 		return DisassemblyHandler.createHandler(stack);
 	}
-
 }


### PR DESCRIPTION
## Changes
Closes #902 

* Adds a check that disables items from being added to the disassembly table if they return nothing
* Disabled Arrow heads in the disassembly station
* Filtered out feathers from results if the input was an arrow