### PR TITLE
[Feature]: Added support for custom parent model files

### DIFF
--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/client/ForgeroClient.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/client/ForgeroClient.java
@@ -95,8 +95,9 @@ public class ForgeroClient implements ClientModInitializer {
 		var materials = ForgeroStateRegistry.TREE.find(Type.TOOL_MATERIAL)
 				.map(node -> node.getResources(State.class))
 				.orElse(ImmutableList.<State>builder().build());
+
 		for (State material : materials) {
-			ForgeroClient.TEXTURES.put(String.format("forgero:%s-repair_kit.png", material.name()), new PaletteTemplateModel(material.name(), "repair_kit.png", 30, null, 16, null, Collections.emptyList()));
+			ForgeroClient.TEXTURES.put(String.format("forgero:%s-repair_kit.png", material.name()), new PaletteTemplateModel(material.name(), "repair_kit.png", 30, null, 16, null, null, Collections.emptyList()));
 		}
 
 		PALETTE_REMAP.putAll(modelRegistry.getPaletteRemapper());

--- a/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-extended/models/longbow_limb.json
+++ b/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-extended/models/longbow_limb.json
@@ -7,6 +7,7 @@
       "template": "longbow_limb.png",
       "palette": "BOW_LIMB_MATERIAL",
       "order": 2,
+      "parent": "minecraft:item/bow",
       "variants": [
         {
           "predicate": [

--- a/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-extended/models/mastercrafted_bow_limb.json
+++ b/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-extended/models/mastercrafted_bow_limb.json
@@ -7,6 +7,7 @@
       "template": "mastercrafted_bow_limb.png",
       "palette": "BOW_LIMB_MATERIAL",
       "order": 2,
+      "parent": "minecraft:item/bow",
       "variants": [
         {
           "predicate": [
@@ -103,36 +104,36 @@
     {
       "name": "bow_dye",
       "variants": [
-          {
-            "predicate": [
-              "model:mastercrafted_bow_pull_2.png",
-              {
-                "type": "forgero:bow_pull",
-                "pull": 0.9
-              }
-            ],
-            "template": "mastercrafted_bow_pull_2.png"
-          },
-          {
-            "predicate": [
-              "model:mastercrafted_bow_pull_1.png",
-              {
-                "type": "forgero:bow_pull",
-                "pull": 0.6
-              }
-            ],
-            "template": "mastercrafted_bow_pull_1.png"
-          },
-          {
-            "predicate": [
-              "model:mastercrafted_bow_pull_0.png",
-              {
-                "type": "forgero:bow_pull",
-                "pull": 0.1
-              }
-            ],
-            "template": "mastercrafted_bow_pull_0.png"
-          },
+        {
+          "predicate": [
+            "model:mastercrafted_bow_pull_2.png",
+            {
+              "type": "forgero:bow_pull",
+              "pull": 0.9
+            }
+          ],
+          "template": "mastercrafted_bow_pull_2.png"
+        },
+        {
+          "predicate": [
+            "model:mastercrafted_bow_pull_1.png",
+            {
+              "type": "forgero:bow_pull",
+              "pull": 0.6
+            }
+          ],
+          "template": "mastercrafted_bow_pull_1.png"
+        },
+        {
+          "predicate": [
+            "model:mastercrafted_bow_pull_0.png",
+            {
+              "type": "forgero:bow_pull",
+              "pull": 0.1
+            }
+          ],
+          "template": "mastercrafted_bow_pull_0.png"
+        },
         {
           "target": [
             "model:mastercrafted_bow_limb.png"

--- a/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-extended/models/refined_bow_limb.json
+++ b/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-extended/models/refined_bow_limb.json
@@ -87,37 +87,37 @@
           ],
           "template": "refined_bow_limb.png"
         },
-          {
-            "predicate": [
-              "model:refined_bow_pull_2.png",
-              {
-                "type": "forgero:bow_pull",
-                "pull": 0.9
-              }
-            ],
-            "template": "refined_bow_pull_2.png"
-          },
-          {
-            "predicate": [
-              "model:refined_bow_pull_1.png",
-              {
-                "type": "forgero:bow_pull",
-                "pull": 0.6
-              }
-            ],
-            "template": "refined_bow_pull_1.png"
-          },
-          {
-            "predicate": [
-              "model:refined_bow_pull_0.png",
-              {
-                "type": "forgero:bow_pull",
-                "pull": 0.1
-              }
-            ],
-            "template": "refined_bow_pull_0.png"
-          }
-        ]
+        {
+          "predicate": [
+            "model:refined_bow_pull_2.png",
+            {
+              "type": "forgero:bow_pull",
+              "pull": 0.9
+            }
+          ],
+          "template": "refined_bow_pull_2.png"
+        },
+        {
+          "predicate": [
+            "model:refined_bow_pull_1.png",
+            {
+              "type": "forgero:bow_pull",
+              "pull": 0.6
+            }
+          ],
+          "template": "refined_bow_pull_1.png"
+        },
+        {
+          "predicate": [
+            "model:refined_bow_pull_0.png",
+            {
+              "type": "forgero:bow_pull",
+              "pull": 0.1
+            }
+          ],
+          "template": "refined_bow_pull_0.png"
+        }
+      ]
     },
     {
       "target": [

--- a/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-extended/models/shortbow_limb.json
+++ b/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-extended/models/shortbow_limb.json
@@ -7,6 +7,7 @@
       "template": "shortbow_limb.png",
       "palette": "BOW_LIMB_MATERIAL",
       "order": 2,
+      "parent": "minecraft:item/bow",
       "variants": [
         {
           "predicate": [

--- a/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-vanilla/models/bow_limb.json
+++ b/fabric/modules/bows/src/main/resources/data/forgero/packs/bows-vanilla/models/bow_limb.json
@@ -7,6 +7,7 @@
       "type": "GENERATE",
       "palette": "BOW_LIMB_MATERIAL",
       "order": 2,
+      "parent": "minecraft:item/bow",
       "variants": [
         {
           "predicate": [
@@ -43,7 +44,6 @@
       "template": "bow_limb_reinforcement.png",
       "palette": "UPGRADE_MATERIAL",
       "order": 5
-
     },
     {
       "name": "bow_grip",

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/CompositeModelTemplate.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/CompositeModelTemplate.java
@@ -1,11 +1,11 @@
 package com.sigmundgranaas.forgero.core.model;
 
-import com.sigmundgranaas.forgero.core.texture.utils.Offset;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import com.sigmundgranaas.forgero.core.texture.utils.Offset;
+import org.jetbrains.annotations.NotNull;
 
 public class CompositeModelTemplate implements ModelTemplate, Comparable<ModelTemplate> {
 	private final List<ModelTemplate> models;
@@ -36,7 +36,7 @@ public class CompositeModelTemplate implements ModelTemplate, Comparable<ModelTe
 	public <T> T convert(Converter<T, ModelTemplate> converter) {
 		return converter.convert(this);
 	}
-
+	
 	@Override
 	public int compareTo(@NotNull ModelTemplate o) {
 		return 0;

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelConverter.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelConverter.java
@@ -309,9 +309,9 @@ public class ModelConverter {
 		if (data.getTemplate().contains(EMPTY_IMAGE_IDENTIFIER)) {
 			return ModelMatcher.EMPTY_TRUE;
 		} else if (data.getTexture().equals(EMPTY_IDENTIFIER)) {
-			template = new PaletteTemplateModel(data.getPalette(), data.getTemplate(), data.order(), Offset.of(data.getOffset()), data.getResolution(), data.displayOverrides().orElse(null), children);
+			template = new PaletteTemplateModel(data.getPalette(), data.getTemplate(), data.order(), Offset.of(data.getOffset()), data.getResolution(), data.displayOverrides().orElse(null), data.getParent().orElse(null), children);
 		} else {
-			template = new TextureModel(data.getTexture(), data.order(), Offset.of(data.getOffset()), data.getResolution(), data.displayOverrides().orElse(null), children);
+			template = new TextureModel(data.getTexture(), data.order(), Offset.of(data.getOffset()), data.getResolution(), data.displayOverrides().orElse(null), data.getParent().orElse(null), children);
 		}
 
 		Identifiable identifiable = (Identifiable) template;

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelTemplate.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelTemplate.java
@@ -13,10 +13,14 @@ public interface ModelTemplate {
 	default Integer getResolution() {
 		return 16;
 	}
-	
+
 	default Optional<JsonObject> getDisplayOverrides() {
 		return Optional.empty();
 	}
 
 	<T> T convert(Converter<T, ModelTemplate> converter);
+
+	default Optional<String> getParent() {
+		return Optional.empty();
+	}
 }

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/PaletteTemplateModel.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/PaletteTemplateModel.java
@@ -13,11 +13,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public record PaletteTemplateModel(String palette,
-								   String template,
-								   int order,
-								   @Nullable Offset offset,
-								   @Nullable Integer resolution,
-								   @Nullable JsonObject displayOverrides,
+                                   String template,
+                                   int order,
+                                   @Nullable Offset offset,
+                                   @Nullable Integer resolution,
+                                   @Nullable JsonObject displayOverrides,
+                                   @Nullable String parent,
                                    List<ModelTemplate> children) implements ModelTemplate, ModelMatcher, Identifiable {
 
 	@Override
@@ -33,6 +34,11 @@ public record PaletteTemplateModel(String palette,
 	@Override
 	public Optional<JsonObject> getDisplayOverrides() {
 		return Optional.ofNullable(displayOverrides);
+	}
+
+	@Override
+	public Optional<String> getParent() {
+		return Optional.ofNullable(parent);
 	}
 
 	@Override

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/TextureModel.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/TextureModel.java
@@ -17,6 +17,7 @@ public record TextureModel(String texture,
                            @Nullable Offset offset,
                            @Nullable Integer resolution,
                            @Nullable JsonObject displayOverrides,
+                           @Nullable String parent,
                            List<ModelTemplate> children) implements ModelTemplate, ModelMatcher, Identifiable {
 
 	@Override
@@ -40,6 +41,11 @@ public record TextureModel(String texture,
 	}
 
 	@Override
+	public Optional<String> getParent() {
+		return Optional.ofNullable(parent);
+	}
+
+	@Override
 	public boolean match(Matchable state, MatchContext context) {
 		return true;
 	}
@@ -52,9 +58,9 @@ public record TextureModel(String texture,
 	@Override
 	public String name() {
 		var split = texture().split(":");
-		if(split.length > 1){
+		if (split.length > 1) {
 			return split[1];
-		}else {
+		} else {
 			return texture();
 		}
 	}
@@ -62,9 +68,9 @@ public record TextureModel(String texture,
 	@Override
 	public String nameSpace() {
 		var split = texture.split(":");
-		if(split.length > 1){
+		if (split.length > 1) {
 			return split[0];
-		}else {
+		} else {
 			return Forgero.NAMESPACE;
 		}
 	}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/ModelData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/ModelData.java
@@ -56,11 +56,15 @@ public class ModelData {
 
 	@Builder.Default
 	@Nullable
-	private String texture =  Identifiers.EMPTY_IDENTIFIER;
+	private String texture = Identifiers.EMPTY_IDENTIFIER;
 
 	@Nullable
 	@SerializedName(value = "display_overrides", alternate = "display")
 	private JsonObject displayOverrides;
+
+	@Nullable
+	@SerializedName(value = "parent")
+	private String parent;
 
 	@Builder.Default
 	@Nullable
@@ -111,6 +115,11 @@ public class ModelData {
 	@NotNull
 	public List<ModelData> getChildren() {
 		return Objects.requireNonNullElse(children, Collections.emptyList());
+	}
+
+	@NotNull
+	public Optional<String> getParent() {
+		return Optional.ofNullable(this.parent);
 	}
 
 	@NotNull


### PR DESCRIPTION
Can be added like this:
```
{
      "name": "shortbow_limb",
      "modelType": "GENERATE",
      "template": "shortbow_limb.png",
      "palette": "BOW_LIMB_MATERIAL",
      "order": 2,
      "parent": "minecraft:item/bow",
 }
```