### PR TITLE
[Feature]: Added a name_replace_planks function to the generator

### DIFF
--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_axe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_axe_head.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "item": "${wood.namespace}:${wood.name}_planks"
+      "item": "${wood.namespace}:${wood.name_replace_planks}_planks"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_handle.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_handle.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "item": "${wood.namespace}:${wood.name}_planks"
+      "item": "${wood.namespace}:${wood.name_replace_planks}_planks"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_pickaxe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_pickaxe_head.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "item": "${wood.namespace}:${wood.name}_planks"
+      "item": "${wood.namespace}:${wood.name_replace_planks}_planks"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_shovel_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_shovel_head.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "item": "${wood.namespace}:${wood.name}_planks"
+      "item": "${wood.namespace}:${wood.name_replace_planks}_planks"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_sword_blade.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_sword_blade.json
@@ -14,7 +14,7 @@
   ],
   "key": {
     "x": {
-      "item": "${wood.namespace}:${wood.name}_planks"
+      "item": "${wood.namespace}:${wood.name_replace_planks}_planks"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_sword_guard.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_sword_guard.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "item": "${wood.namespace}:${wood.name}_planks"
+      "item": "${wood.namespace}:${wood.name_replace_planks}_planks"
     },
     "i": {
       "item": "${wood.namespace}:${wood.name}_slab"

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPostInit.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPostInit.java
@@ -115,6 +115,9 @@ public class ForgeroPostInit implements ForgeroInitializedEntryPoint {
 		operation("forgero:state_identifier", "id", factory.build(idConverter));
 		operation("forgero:tag_or_item", "tagOrItem", factory.build(tagOrItem));
 
+		// Edge cases
+		operation("forgero:state_name_replace_planks", "name_replace_planks", factory.build((State state) -> state.name().replace("_planks", "")));
+
 		Function<String, List<State>> stateFinder = (type) -> ForgeroStateRegistry.TREE.find(Type.of(type))
 				.map(node -> node.getResources(State.class))
 				.orElse(ImmutableList.<State>builder()


### PR DESCRIPTION
Makes it possible to integrate other wood types that include the "_plank" part in their name.

Example:
```json
      "item": "${wood.namespace}:${wood.name_replace_planks}_planks"
```