### PR TITLE
[Patch]: Remove windows and macos from build actions

### DIFF
--- a/.github/workflows/build_fabric.yml
+++ b/.github/workflows/build_fabric.yml
@@ -31,7 +31,7 @@ jobs:
   build_fabric:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     needs: skip_duplicate_jobs
     if: needs.skip_duplicate_jobs.outputs.should_skip != 'true'


### PR DESCRIPTION
Removed MacOs and Windows from build step because of stability issues with the tests