### PR TITLE
[Patch]: Fix generated common wood recipes

### DIFF
--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/basic_short_sword_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/basic_short_sword_blade.json
@@ -14,7 +14,7 @@
   ],
   "key": {
     "x": {
-      "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_planks"
+      "${wood.tagOrItem}": "${wood.container_id}"
     }
   },
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/unique_schematic_recipes/2_material_parts.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/unique_schematic_recipes/2_material_parts.json
@@ -27,10 +27,10 @@
       "item": "forgero:${variant}-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/unique_schematic_recipes/3_material_parts.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/unique_schematic_recipes/3_material_parts.json
@@ -22,13 +22,13 @@
       "item": "forgero:${variant}-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/unique_schematic_recipes/4_material_parts.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/unique_schematic_recipes/4_material_parts.json
@@ -16,16 +16,16 @@
       "item": "forgero:${variant}-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/axe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/axe_head.json
@@ -16,13 +16,13 @@
       "item": "forgero:${variant}_axe_head-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/handle.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/handle.json
@@ -16,10 +16,10 @@
       "item": "forgero:${variant}_handle-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/hoe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/hoe_head.json
@@ -16,10 +16,10 @@
       "item": "forgero:${variant}_hoe_head-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/pickaxe_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/pickaxe_head.json
@@ -16,13 +16,13 @@
       "item": "forgero:${variant}_pickaxe_head-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/pommel.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/pommel.json
@@ -17,7 +17,7 @@
       "item": "forgero:${variant}pommel-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/shovel_head.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/shovel_head.json
@@ -16,7 +16,7 @@
       "item": "forgero:${variant}_shovel_head-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/sword_blade.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/sword_blade.json
@@ -16,13 +16,13 @@
       "item": "forgero:${variant}_sword_blade-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/sword_guard.json
+++ b/content/forgero-extended/src/main/resources/data/forgero/recipe_generators/variant_schematic_recipes/sword_guard.json
@@ -16,10 +16,10 @@
       "item": "forgero:${variant}_sword_guard-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/axe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/axe_head.json
@@ -12,13 +12,13 @@
       "item": "forgero:axe_head-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/binding.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/binding.json
@@ -12,10 +12,10 @@
       "item": "forgero:binding-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/handle.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/handle.json
@@ -12,10 +12,10 @@
       "item": "forgero:handle-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/hoe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/hoe_head.json
@@ -12,10 +12,10 @@
       "item": "forgero:hoe_head-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/pickaxe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/pickaxe_head.json
@@ -12,13 +12,13 @@
       "item": "forgero:pickaxe_head-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/shovel_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/shovel_head.json
@@ -12,7 +12,7 @@
       "item": "forgero:shovel_head-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/sword_blade.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/sword_blade.json
@@ -12,10 +12,10 @@
       "item": "forgero:sword_blade-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/sword_guard.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/schematic_recipes/sword_guard.json
@@ -12,10 +12,10 @@
       "item": "forgero:sword_guard-schematic"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     }
   ],
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_axe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_axe_head.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_planks"
+      "${wood.tagOrItem}": "${wood.container_id}"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_handle.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_handle.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_planks"
+      "${wood.tagOrItem}": "${wood.container_id}"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_hoe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_hoe_head.json
@@ -12,7 +12,7 @@
   ],
   "key": {
     "x": {
-      "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_planks"
+      "${wood.tagOrItem}": "${wood.container_id}"
     },
     "i": {
       "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_slab"

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_pickaxe_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_pickaxe_head.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_planks"
+      "${wood.tagOrItem}": "${wood.container_id}"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_shovel_head.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_shovel_head.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_planks"
+      "${wood.tagOrItem}": "${wood.container_id}"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_sword_blade.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_sword_blade.json
@@ -14,7 +14,7 @@
   ],
   "key": {
     "x": {
-      "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_planks"
+      "${wood.tagOrItem}": "${wood.container_id}"
     }
   },
   "result": {

--- a/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_sword_guard.json
+++ b/content/forgero-vanilla/src/main/resources/data/forgero/recipe_generators/simple_wood/basic_sword_guard.json
@@ -13,7 +13,7 @@
   ],
   "key": {
     "x": {
-      "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_planks"
+      "${wood.tagOrItem}": "${wood.container_id}"
     },
     "i": {
       "${wood.tagOrItem}": "${wood.namespace}:${wood.name_replace_planks}_slab"

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPostInit.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPostInit.java
@@ -51,9 +51,6 @@ import com.sigmundgranaas.forgero.minecraft.common.registry.registrar.LootFuncti
 import com.sigmundgranaas.forgero.minecraft.common.service.StateService;
 import com.sigmundgranaas.forgero.minecraft.common.toolhandler.HungerHandler;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.v2.TooltipAttributeRegistry;
-
-import net.minecraft.util.Identifier;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -100,28 +97,22 @@ public class ForgeroPostInit implements ForgeroInitializedEntryPoint {
 		registerAARPRecipes(stateService);
 		registerHungerCallbacks(stateService);
 		registerToolTipFilters();
-		registerRecipeGenerators(stateService);
+		registerRecipeGenerators();
 	}
 
-	private void registerRecipeGenerators(StateService stateService) {
-		Function<State, String> idConverter = s -> stateService.getMapper().stateToContainer(s.identifier()).toString();
+	private void registerRecipeGenerators() {
+		Function<State, String> idConverter = s -> StateService.INSTANCE.getMapper().stateToContainer(s.identifier()).toString();
 
-		Function<State, String> tagOrItem = (state) -> Registries.ITEM.get(stateService.getMapper().stateToContainer(state.identifier())) == Items.AIR ? "tag" : "item";
+		Function<State, String> tagOrItem = (state) -> Registries.ITEM.get(StateService.INSTANCE.getMapper().stateToContainer(state.identifier())) == Items.AIR ? "tag" : "item";
 		Function<State, String> material = (state) -> state instanceof MaterialBased based ? based.baseMaterial().name() : "";
-		Function<State, String> namespace = (state) -> stateService.getMapper().stateToTag(state.identifier()).map(Identifier::getNamespace)
-				.orElse(state.nameSpace());
-		Function<State, String> containerId = (state) -> stateService.getMapper().stateToTag(state.identifier()).map(Identifier::toString)
-				.orElse(stateService.getMapper().stateToContainer(state.identifier()).toString());
 
 		var factory = new OperationFactory<>(State.class);
 
 		operation("forgero:state_name", "name", factory.build(Identifiable::name));
-		operation("forgero:state_namespace", "namespace", factory.build(namespace));
+		operation("forgero:state_namespace", "namespace", factory.build(Identifiable::nameSpace));
 		operation("forgero:state_material", "material", factory.build(material));
 		operation("forgero:state_identifier", "identifier", factory.build(idConverter));
 		operation("forgero:state_identifier", "id", factory.build(idConverter));
-		operation("forgero:state_identifier", "container_id", factory.build(containerId));
-
 		operation("forgero:tag_or_item", "tagOrItem", factory.build(tagOrItem));
 
 		// Edge cases

--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPostInit.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPostInit.java
@@ -51,6 +51,9 @@ import com.sigmundgranaas.forgero.minecraft.common.registry.registrar.LootFuncti
 import com.sigmundgranaas.forgero.minecraft.common.service.StateService;
 import com.sigmundgranaas.forgero.minecraft.common.toolhandler.HungerHandler;
 import com.sigmundgranaas.forgero.minecraft.common.tooltip.v2.TooltipAttributeRegistry;
+
+import net.minecraft.util.Identifier;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -97,22 +100,28 @@ public class ForgeroPostInit implements ForgeroInitializedEntryPoint {
 		registerAARPRecipes(stateService);
 		registerHungerCallbacks(stateService);
 		registerToolTipFilters();
-		registerRecipeGenerators();
+		registerRecipeGenerators(stateService);
 	}
 
-	private void registerRecipeGenerators() {
-		Function<State, String> idConverter = s -> StateService.INSTANCE.getMapper().stateToContainer(s.identifier()).toString();
+	private void registerRecipeGenerators(StateService stateService) {
+		Function<State, String> idConverter = s -> stateService.getMapper().stateToContainer(s.identifier()).toString();
 
-		Function<State, String> tagOrItem = (state) -> Registries.ITEM.get(StateService.INSTANCE.getMapper().stateToContainer(state.identifier())) == Items.AIR ? "tag" : "item";
+		Function<State, String> tagOrItem = (state) -> Registries.ITEM.get(stateService.getMapper().stateToContainer(state.identifier())) == Items.AIR ? "tag" : "item";
 		Function<State, String> material = (state) -> state instanceof MaterialBased based ? based.baseMaterial().name() : "";
+		Function<State, String> namespace = (state) -> stateService.getMapper().stateToTag(state.identifier()).map(Identifier::getNamespace)
+				.orElse(state.nameSpace());
+		Function<State, String> containerId = (state) -> stateService.getMapper().stateToTag(state.identifier()).map(Identifier::toString)
+				.orElse(stateService.getMapper().stateToContainer(state.identifier()).toString());
 
 		var factory = new OperationFactory<>(State.class);
 
 		operation("forgero:state_name", "name", factory.build(Identifiable::name));
-		operation("forgero:state_namespace", "namespace", factory.build(Identifiable::nameSpace));
+		operation("forgero:state_namespace", "namespace", factory.build(namespace));
 		operation("forgero:state_material", "material", factory.build(material));
 		operation("forgero:state_identifier", "identifier", factory.build(idConverter));
 		operation("forgero:state_identifier", "id", factory.build(idConverter));
+		operation("forgero:state_identifier", "container_id", factory.build(containerId));
+
 		operation("forgero:tag_or_item", "tagOrItem", factory.build(tagOrItem));
 
 		// Edge cases

--- a/fabric/modules/bows/src/main/resources/data/forgero/recipe_generators/simple_arrow.json
+++ b/fabric/modules/bows/src/main/resources/data/forgero/recipe_generators/simple_arrow.json
@@ -14,7 +14,7 @@
   ],
   "key": {
     "a": {
-      "${material.tagOrItem}": "${material.id}"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     "b": {
       "tag": "forgero:handle"

--- a/fabric/modules/bows/src/main/resources/data/forgero/recipe_generators/simple_wooden_bow.json
+++ b/fabric/modules/bows/src/main/resources/data/forgero/recipe_generators/simple_wooden_bow.json
@@ -14,7 +14,7 @@
   ],
   "key": {
     "a": {
-      "${material.tagOrItem}": "${material.namespace}:${material.name_replace_planks}_planks"
+      "${material.tagOrItem}": "${material.container_id}"
     },
     "b": {
       "tag": "forgero:string"


### PR DESCRIPTION
 Added better methods for mapping from states to container id's and namespaces in recipes.

Closes #1036 