### PR TITLE
[Patch]: Created a new setup for registering common tags

### DIFF
--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/ForgeroCompatInitializer.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/ForgeroCompatInitializer.java
@@ -3,6 +3,8 @@ package com.sigmundgranaas.forgero.fabric;
 import java.util.function.Supplier;
 
 import com.sigmundgranaas.forgero.fabric.api.entrypoint.ForgeroInitializedEntryPoint;
+import com.sigmundgranaas.forgero.fabric.tags.CommonTagGenerator;
+import com.sigmundgranaas.forgero.fabric.tags.CommonTags;
 import com.sigmundgranaas.forgero.fabric.tags.Create;
 import com.sigmundgranaas.forgero.fabric.tags.Ecologics;
 import com.sigmundgranaas.forgero.fabric.tags.MythicMetalsCommons;
@@ -22,35 +24,14 @@ import net.fabricmc.loader.api.FabricLoader;
 public class ForgeroCompatInitializer implements ForgeroInitializedEntryPoint {
 	public static final Supplier<Boolean> toolstats;
 	public static final Supplier<Boolean> bettercombat;
-	public static final Supplier<Boolean> mythicmetals;
 	public static final Supplier<Boolean> yacl;
 	public static final Supplier<Boolean> emi;
 	public static final Supplier<Boolean> modonomicon;
-	public static final Supplier<Boolean> beachparty;
-	public static final Supplier<Boolean> modernindustrialization;
-	public static final Supplier<Boolean> natures_spirit;
-	public static final Supplier<Boolean> create;
-	public static final Supplier<Boolean> ecologics;
-	public static final Supplier<Boolean> biomeswevegone;
-
-	public static final Supplier<Boolean> techreborn;
-	public static final Supplier<Boolean> bloomingnature;
-	public static final Supplier<Boolean> meadow;
 
 	static {
-		beachparty = () -> isModLoaded("beachparty");
-		bloomingnature = () -> isModLoaded("bloomingnature");
-		techreborn = () -> isModLoaded("techreborn");
-		modernindustrialization = () -> isModLoaded("modernindustrialization");
-		ecologics = () -> isModLoaded("ecologics");
-		create = () -> isModLoaded("create");
-		biomeswevegone = () -> isModLoaded("biomeswevegone");
-		meadow = () -> isModLoaded("meadow");
 		modonomicon = () -> isModLoaded("modonomicon");
 		toolstats = () -> isModLoaded("toolstats");
 		emi = () -> isModLoaded("emi");
-		natures_spirit = () -> isModLoaded("natures_spirit");
-		mythicmetals = () -> isModLoaded("mythicmetals");
 		bettercombat = () -> isModLoaded("bettercombat");
 		yacl = () -> isModLoaded("yet-another-config-lib") || isModLoaded("yet_another_config_lib_v3");
 	}
@@ -69,44 +50,8 @@ public class ForgeroCompatInitializer implements ForgeroInitializedEntryPoint {
 			BookDropOnAdvancement.registerBookDrop();
 		}
 
-		if (mythicmetals.get()) {
-			MythicMetalsCommons.generateTags();
-		}
-
-		if (modernindustrialization.get()) {
-			ModernIndustrialization.generateTags();
-		}
-
-		if (biomeswevegone.get()) {
-			BiomesWeveGone.generateTags();
-		}
-
-		if (natures_spirit.get()) {
-			NaturesSpirit.generateTags();
-		}
-
-		if (ecologics.get()) {
-			Ecologics.generateTags();
-		}
-
-		if (create.get()) {
-			Create.generateTags();
-		}
-
-		if (techreborn.get()) {
-			TechReborn.generateTags();
-		}
-
-		if (bloomingnature.get()) {
-			BloomingNature.generateTags();
-		}
-
-		if (beachparty.get()) {
-			BeachParty.generateTags();
-		}
-
-		if (meadow.get()) {
-			Meadow.generateTags();
-		}
+		// Goes through all mod compats that has common materials and checks if the mod is loaded and adds all of their tags to a separate resource pack
+		// Each mod gets its own runtime resource pack to avoid them overriding each other.
+		CommonTags.registerAndFilterCommonMaterialTags();
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/BeachParty.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/BeachParty.java
@@ -1,13 +1,12 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+public class BeachParty extends CommonTagGenerator {
+	protected BeachParty() {
+		super("beachparty");
+	}
 
-import net.devtech.arrp.json.tags.JTag;
-
-import net.minecraft.util.Identifier;
-
-public class BeachParty {
-	public static void generateTags() {
-		RESOURCE_PACK.addTag(new Identifier("c", "items/palm_planks"), JTag.tag().add(new Identifier("beachparty:palm_planks")));
+	@Override
+	public void addTags() {
+		registerCommonItemTag("palm_planks");
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/BiomesWeveGone.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/BiomesWeveGone.java
@@ -1,22 +1,22 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+public class BiomesWeveGone extends CommonTagGenerator {
 
-import net.devtech.arrp.json.tags.JTag;
+	protected BiomesWeveGone() {
+		super("biomeswevegone");
+	}
 
-import net.minecraft.util.Identifier;
-
-public class BiomesWeveGone {
-	public static void generateTags() {
-		RESOURCE_PACK.addTag(new Identifier("c", "items/aspen_planks"), JTag.tag().add(new Identifier("biomeswevegone:aspen_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/baobab_planks"), JTag.tag().add(new Identifier("biomeswevegone:baobab_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/cypress_planks"), JTag.tag().add(new Identifier("biomeswevegone:cypress_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/fir_planks"), JTag.tag().add(new Identifier("biomeswevegone:fir_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/mahogany_planks"), JTag.tag().add(new Identifier("biomeswevegone:mahogany_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/maple_planks"), JTag.tag().add(new Identifier("biomeswevegone:maple_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/palm_planks"), JTag.tag().add(new Identifier("biomeswevegone:palm_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/pine_planks"), JTag.tag().add(new Identifier("biomeswevegone:pine_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/redwood_planks"), JTag.tag().add(new Identifier("biomeswevegone:redwood_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/willow_planks"), JTag.tag().add(new Identifier("biomeswevegone:willow_planks")));
+	@Override
+	public void addTags() {
+		registerCommonItemTag("aspen_planks");
+		registerCommonItemTag("baobab_planks");
+		registerCommonItemTag("cypress_planks");
+		registerCommonItemTag("fir_planks");
+		registerCommonItemTag("mahogany_planks");
+		registerCommonItemTag("maple_planks");
+		registerCommonItemTag("palm_planks");
+		registerCommonItemTag("pine_planks");
+		registerCommonItemTag("redwood_planks");
+		registerCommonItemTag("willow_planks");
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/BloomingNature.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/BloomingNature.java
@@ -1,17 +1,16 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+public class BloomingNature extends CommonTagGenerator {
+	protected BloomingNature() {
+		super("bloomingnature");
+	}
 
-import net.devtech.arrp.json.tags.JTag;
-
-import net.minecraft.util.Identifier;
-
-public class BloomingNature {
-	public static void generateTags() {
-		RESOURCE_PACK.addTag(new Identifier("c", "items/aspen_planks"), JTag.tag().add(new Identifier("bloomingnature:aspen_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/baobab_planks"), JTag.tag().add(new Identifier("bloomingnature:baobab_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/ebony_planks"), JTag.tag().add(new Identifier("bloomingnature:ebony_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/fir_planks"), JTag.tag().add(new Identifier("bloomingnature:fir_planks")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/larch_planks"), JTag.tag().add(new Identifier("bloomingnature:larch_planks")));
+	@Override
+	public void addTags() {
+		registerCommonItemTag("aspen_planks");
+		registerCommonItemTag("baobab_planks");
+		registerCommonItemTag("ebony_planks");
+		registerCommonItemTag("fir_planks");
+		registerCommonItemTag("larch_planks");
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/CommonTagGenerator.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/CommonTagGenerator.java
@@ -1,0 +1,41 @@
+package com.sigmundgranaas.forgero.fabric.tags;
+
+import com.sigmundgranaas.forgero.core.Forgero;
+import com.sigmundgranaas.forgero.fabric.ForgeroCompatInitializer;
+import net.devtech.arrp.api.RRPCallback;
+import net.devtech.arrp.api.RuntimeResourcePack;
+import net.devtech.arrp.json.tags.JTag;
+
+import net.minecraft.util.Identifier;
+
+public abstract class CommonTagGenerator {
+	private final String mod;
+	private final String namespace;
+	private  RuntimeResourcePack resourcePack;
+
+	protected CommonTagGenerator(String mod, String namespace) {
+		this.mod = mod;
+		this.namespace = namespace;
+	}
+
+	protected CommonTagGenerator(String mod) {
+		this.mod = mod;
+		this.namespace = mod;
+	}
+
+	public abstract void addTags();
+
+	public void register(){
+		this.resourcePack = RuntimeResourcePack.create("%s:%s_common_tags".formatted(Forgero.NAMESPACE, mod));
+		addTags();
+		RRPCallback.BEFORE_VANILLA.register(a -> a.add(resourcePack));
+	}
+
+	public boolean isModLoaded(){
+		return ForgeroCompatInitializer.isModLoaded(mod);
+	}
+
+	protected void registerCommonItemTag(String item){
+		resourcePack.addTag(new Identifier("c", "items/" + item), JTag.tag().add(new Identifier(namespace, item)));
+	}
+}

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/CommonTags.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/CommonTags.java
@@ -1,0 +1,27 @@
+package com.sigmundgranaas.forgero.fabric.tags;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public class CommonTags {
+	private static final List<Supplier<CommonTagGenerator>> TAGS = List.of(
+			BiomesWeveGone::new,
+			BiomesWeveGone::new,
+			BloomingNature::new,
+			Create::new,
+			Ecologics::new,
+			Meadow::new,
+			ModernIndustrialization::new,
+			MythicMetalsCommons::new,
+			NaturesSpirit::new,
+			TechReborn::new,
+			RegionsUnexplored::new
+	);
+
+	public static void registerAndFilterCommonMaterialTags(){
+		TAGS.stream()
+				.map(Supplier::get)
+				.filter(CommonTagGenerator::isModLoaded)
+				.forEach(CommonTagGenerator::register);
+	}
+}

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/Create.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/Create.java
@@ -1,15 +1,14 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+public class Create extends CommonTagGenerator {
+	protected Create() {
+		super("create");
+	}
 
-import net.devtech.arrp.json.tags.JTag;
-
-import net.minecraft.util.Identifier;
-
-public class Create {
-	public static void generateTags() {
-		RESOURCE_PACK.addTag(new Identifier("c", "items/brass_ingot"), JTag.tag().add(new Identifier("create:brass_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/zinc_ingot"), JTag.tag().add(new Identifier("create:zinc_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/limestone"), JTag.tag().add(new Identifier("create:limestone")));
+	@Override
+	public void addTags() {
+		registerCommonItemTag("brass_ingot");
+		registerCommonItemTag("zinc_ingot");
+		registerCommonItemTag("zinc_ingot");
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/Ecologics.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/Ecologics.java
@@ -1,13 +1,12 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+public class Ecologics extends CommonTagGenerator {
+	protected Ecologics() {
+		super("ecologics");
+	}
 
-import net.devtech.arrp.json.tags.JTag;
-
-import net.minecraft.util.Identifier;
-
-public class Ecologics {
-	public static void generateTags() {
-		RESOURCE_PACK.addTag(new Identifier("c", "items/coconut_planks"), JTag.tag().add(new Identifier("ecologics:coconut_planks")));
+	@Override
+	public void addTags() {
+		registerCommonItemTag("coconut_planks");
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/Meadow.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/Meadow.java
@@ -1,14 +1,13 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+public class Meadow extends CommonTagGenerator {
+	protected Meadow() {
+		super("meadow");
+	}
 
-import net.devtech.arrp.json.tags.JTag;
-
-import net.minecraft.util.Identifier;
-
-public class Meadow {
-	public static void generateTags() {
-		RESOURCE_PACK.addTag(new Identifier("c", "items/limestone"), JTag.tag().add(new Identifier("meadow:limestone")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/pine_planks"), JTag.tag().add(new Identifier("meadow:pine_planks")));
+	@Override
+	public void addTags() {
+		registerCommonItemTag("limestone");
+		registerCommonItemTag("pine_planks");
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/ModernIndustrialization.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/ModernIndustrialization.java
@@ -1,25 +1,24 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+public class ModernIndustrialization extends CommonTagGenerator {
+	protected ModernIndustrialization() {
+		super("modernindustrialization","modern_industrialization");
+	}
 
-import net.devtech.arrp.json.tags.JTag;
-
-import net.minecraft.util.Identifier;
-
-public class ModernIndustrialization {
-	public static void generateTags() {
-		RESOURCE_PACK.addTag(new Identifier("c", "items/bronze_ingot"), JTag.tag().add(new Identifier("modern_industrialization:bronze_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/steel_ingot"), JTag.tag().add(new Identifier("modern_industrialization:steel_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/aluminum_ingot"), JTag.tag().add(new Identifier("modern_industrialization:aluminum_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/lead_ingot"), JTag.tag().add(new Identifier("modern_industrialization:lead_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/invar_ingot"), JTag.tag().add(new Identifier("modern_industrialization:invar_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/nickel_ingot"), JTag.tag().add(new Identifier("modern_industrialization:nickel_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/silver_ingot"), JTag.tag().add(new Identifier("modern_industrialization:silver_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/titanium_ingot"), JTag.tag().add(new Identifier("modern_industrialization:titanium_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/electrum_ingot"), JTag.tag().add(new Identifier("modern_industrialization:electrum_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/chromium_ingot"), JTag.tag().add(new Identifier("modern_industrialization:chromium_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/platinum_ingot"), JTag.tag().add(new Identifier("modern_industrialization:platinum_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/iridium_ingot"), JTag.tag().add(new Identifier("modern_industrialization:iridium_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/tungsten_ingot"), JTag.tag().add(new Identifier("modern_industrialization:tungsten_ingot")));
+	@Override
+	public void addTags() {
+		registerCommonItemTag("bronze_ingot");
+		registerCommonItemTag("steel_ingot");
+		registerCommonItemTag("aluminum_ingot");
+		registerCommonItemTag("lead_ingot");
+		registerCommonItemTag("invar_ingot");
+		registerCommonItemTag("nickel_ingot");
+		registerCommonItemTag("silver_ingot");
+		registerCommonItemTag("titanium_ingot");
+		registerCommonItemTag("electrum_ingot");
+		registerCommonItemTag("chromium_ingot");
+		registerCommonItemTag("platinum_ingot");
+		registerCommonItemTag("iridium_ingot");
+		registerCommonItemTag("tungsten_ingot");
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/MythicMetalsCommons.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/MythicMetalsCommons.java
@@ -1,15 +1,14 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+public class MythicMetalsCommons extends CommonTagGenerator {
+	protected MythicMetalsCommons() {
+		super("mythicmetals");
+	}
 
-import net.devtech.arrp.json.tags.JTag;
-
-import net.minecraft.util.Identifier;
-
-public class MythicMetalsCommons {
-	public static void generateTags() {
-		RESOURCE_PACK.addTag(new Identifier("c", "items/silver_ingot"), JTag.tag().add(new Identifier("mythicmetals:silver_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/bronze_ingot"), JTag.tag().add(new Identifier("mythicmetals:bronze_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/steel_ingot"), JTag.tag().add(new Identifier("mythicmetals:steel_ingot")));
+	@Override
+	public void addTags() {
+		registerCommonItemTag("silver_ingot");
+		registerCommonItemTag("bronze_ingot");
+		registerCommonItemTag("steel_ingot");
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/RegionsUnexplored.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/RegionsUnexplored.java
@@ -1,8 +1,8 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-public class NaturesSpirit extends CommonTagGenerator {
-	protected NaturesSpirit() {
-		super("natures_spirit");
+public class RegionsUnexplored extends CommonTagGenerator {
+	protected RegionsUnexplored() {
+		super("regions_unexplored");
 	}
 
 	@Override
@@ -13,6 +13,7 @@ public class NaturesSpirit extends CommonTagGenerator {
 		registerCommonItemTag("maple_planks");
 		registerCommonItemTag("redwood_planks");
 		registerCommonItemTag("willow_planks");
-		registerCommonItemTag("coconut_planks");
+		registerCommonItemTag("pine_planks");
+		registerCommonItemTag("baobab_planks");
 	}
 }

--- a/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/TechReborn.java
+++ b/fabric/forgero-fabric-compat/src/main/java/com/sigmundgranaas/forgero/fabric/tags/TechReborn.java
@@ -1,27 +1,26 @@
 package com.sigmundgranaas.forgero.fabric.tags;
 
-import static com.sigmundgranaas.forgero.fabric.resources.ARRPGenerator.RESOURCE_PACK;
+public class TechReborn extends CommonTagGenerator {
+	protected TechReborn() {
+		super("techreborn");
+	}
 
-import net.devtech.arrp.json.tags.JTag;
-
-import net.minecraft.util.Identifier;
-
-public class TechReborn {
-	public static void generateTags() {
-		RESOURCE_PACK.addTag(new Identifier("c", "items/zinc_ingot"), JTag.tag().add(new Identifier("techreborn:zinc_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/steel_ingot"), JTag.tag().add(new Identifier("techreborn:steel_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/lead_ingot"), JTag.tag().add(new Identifier("techreborn:lead_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/nickel_ingot"), JTag.tag().add(new Identifier("techreborn:nickel_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/bronze_ingot"), JTag.tag().add(new Identifier("techreborn:bronze_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/brass_ingot"), JTag.tag().add(new Identifier("techreborn:brass_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/invar_ingot"), JTag.tag().add(new Identifier("techreborn:invar_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/silver_ingot"), JTag.tag().add(new Identifier("techreborn:silver_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/electrum_ingot"), JTag.tag().add(new Identifier("techreborn:electrum_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/aluminum_ingot"), JTag.tag().add(new Identifier("techreborn:aluminum_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/titanium_ingot"), JTag.tag().add(new Identifier("techreborn:titanium_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/chromium_ingot"), JTag.tag().add(new Identifier("techreborn:chrome_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/iridium_ingot"), JTag.tag().add(new Identifier("techreborn:iridium_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/tungsten_ingot"), JTag.tag().add(new Identifier("techreborn:tungsten_ingot")));
-		RESOURCE_PACK.addTag(new Identifier("c", "items/platinum_ingot"), JTag.tag().add(new Identifier("techreborn:platinum_ingot")));
+	@Override
+	public void addTags() {
+		registerCommonItemTag("zinc_ingot");
+		registerCommonItemTag("steel_ingot");
+		registerCommonItemTag("lead_ingot");
+		registerCommonItemTag("nickel_ingot");
+		registerCommonItemTag("bronze_ingot");
+		registerCommonItemTag("brass_ingot");
+		registerCommonItemTag("invar_ingot");
+		registerCommonItemTag("silver_ingot");
+		registerCommonItemTag("electrum_ingot");
+		registerCommonItemTag("aluminum_ingot");
+		registerCommonItemTag("titanium_ingot");
+		registerCommonItemTag("chromium_ingot");
+		registerCommonItemTag("iridium_ingot");
+		registerCommonItemTag("tungsten_ingot");
+		registerCommonItemTag("platinum_ingot");
 	}
 }


### PR DESCRIPTION
Changes how common item tags are registered to make each mod create a new dynamic resource pack for the tags. This solves the issue of mods overriding tags added by other mods in the same resource packs.

Example:
```
public class ModernIndustrialization extends CommonTagGenerator {
	protected ModernIndustrialization() {
		super("modernindustrialization","modern_industrialization");
	}

	@Override
	public void addTags() {
		registerCommonItemTag("bronze_ingot");
		registerCommonItemTag("steel_ingot");
		registerCommonItemTag("aluminum_ingot");
		registerCommonItemTag("lead_ingot");
		registerCommonItemTag("invar_ingot");
		registerCommonItemTag("nickel_ingot");
		registerCommonItemTag("silver_ingot");
		registerCommonItemTag("titanium_ingot");
		registerCommonItemTag("electrum_ingot");
		registerCommonItemTag("chromium_ingot");
		registerCommonItemTag("platinum_ingot");
		registerCommonItemTag("iridium_ingot");
		registerCommonItemTag("tungsten_ingot");
	}
}
```

Registering it in `CommonTags`
```
	private static final List<Supplier<CommonTagGenerator>> TAGS = List.of(
			...
			ModernIndustrialization::new
	);
```