### PR TITLE
[Patch]: Added support for applying overrides in model variants

### DIFF
--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/client/model/baked/DefaultedDynamicBakedModel.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/client/model/baked/DefaultedDynamicBakedModel.java
@@ -31,6 +31,7 @@ public class DefaultedDynamicBakedModel implements ContextAwareBakedModel, ItemM
 	@Nullable
 	private BakedModel defaultModel;
 	private final ItemStack stack;
+	private BakedModel lastUsedModel;
 
 	public DefaultedDynamicBakedModel(ModelStrategy strategy, StateService service, ItemStack stack) {
 		this.strategy = strategy;
@@ -62,8 +63,8 @@ public class DefaultedDynamicBakedModel implements ContextAwareBakedModel, ItemM
 					.or(() -> Optional.ofNullable(defaultModel))
 					.orElse(EMPTY);
 
+			this.lastUsedModel = model;
 			return model.getOverrides().apply(model, stack, world, entity, seed);
-
 		}
 		return EMPTY;
 	}
@@ -75,6 +76,10 @@ public class DefaultedDynamicBakedModel implements ContextAwareBakedModel, ItemM
 
 	@Override
 	public ModelTransformation getTransformationWithContext(ItemStack stack, ClientWorld world, LivingEntity entity, int seed) {
+		if(lastUsedModel != null){
+			return lastUsedModel.getTransformation();
+		}
+
 		if (defaultModel != null) {
 			return defaultModel.getTransformation();
 		}

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelConverter.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/model/ModelConverter.java
@@ -279,6 +279,7 @@ public class ModelConverter {
 										.offset(variant.getOffset())
 										.resolution(variant.getResolution())
 										.order(data.order())
+										.displayOverrides(variant.getDisplayOverrides().or(data::displayOverrides).orElse(null))
 										.build()),
 						Stream.of(data))
 				.collect(Collectors.toList());

--- a/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/ModelEntryData.java
+++ b/forgero-core/src/main/java/com/sigmundgranaas/forgero/core/resource/data/v2/data/ModelEntryData.java
@@ -3,10 +3,12 @@ package com.sigmundgranaas.forgero.core.resource.data.v2.data;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import com.sigmundgranaas.forgero.core.util.Identifiers;
 import lombok.Builder;
@@ -39,6 +41,10 @@ public class ModelEntryData {
 	@Builder.Default
 	@Nullable
 	private String texture =  Identifiers.EMPTY_IDENTIFIER;
+
+	@Nullable
+	@SerializedName(value = "display_overrides", alternate = "display")
+	private JsonObject displayOverrides;
 
 	@NotNull
 	public List<Float> getOffset() {
@@ -73,5 +79,10 @@ public class ModelEntryData {
 	@NotNull
 	public String getTexture() {
 		return Objects.requireNonNullElse(texture, Identifiers.EMPTY_IDENTIFIER);
+	}
+
+	@NotNull
+	public Optional<JsonObject> getDisplayOverrides() {
+		return Optional.ofNullable(displayOverrides);
 	}
 }


### PR DESCRIPTION
Closes #1102 

Example variant:
```
{
          "predicate": [
            {
              "type": "forgero:bow_pull",
              "pull": 0.9
            }
          ],
          "display_overrides": {
            "thirdperson_righthand": {
              "rotation": [ -90, 0, -60 ],
              "translation": [ 2, 0.1, -3 ],
              "scale": [ 0.9, 0.9, 0.9 ]
            },
            "thirdperson_lefthand": {
              "rotation": [ -90, 0, 30 ],
              "translation": [ 2, 0.1, -3 ],
              "scale": [ 0.9, 0.9, 0.9 ]
            },
            "firstperson_righthand": {
              "rotation": [ -90, 0, -55 ],
              "translation": [ 1.13, 3.2, 1.13],
              "scale": [ 0.68, 0.68, 0.68 ]
            },
            "firstperson_lefthand": {
              "rotation": [ -90, 0, 35 ],
              "translation": [ 1.13, 3.2, 1.13],
              "scale": [ 0.68, 0.68, 0.68 ]
            }
          },
          "template": "bow_pull_2.png"
        },
```

Result:

https://github.com/user-attachments/assets/a962948c-7242-46bf-ba14-61c2f5373949

