### PR TITLE
[Feature]: Predicate for checking if a player is using an item

### DIFF
--- a/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPreInit.java
+++ b/fabric/forgero-fabric-core/src/main/java/com/sigmundgranaas/forgero/fabric/initialization/ForgeroPreInit.java
@@ -193,6 +193,7 @@ public class ForgeroPreInit implements ForgeroPreInitializationEntryPoint {
 		ENTITY_FLAG_PREDICATE_REGISTRY.register(IS_SPRINTING);
 		ENTITY_FLAG_PREDICATE_REGISTRY.register(IS_SWIMMING);
 		ENTITY_FLAG_PREDICATE_REGISTRY.register(IS_ON_GROUND);
+		ENTITY_FLAG_PREDICATE_REGISTRY.register(IS_USING);
 
 		// Key options
 		ENTITY_CODEC_REGISTRY.register(KeyPair.pair(FlagGroupPredicate.KEY, FlagGroupPredicate.CODEC_SPECIFICATION));

--- a/fabric/forgero-fabric-core/src/test/java/com/sigmundgranaas/forgero/fabric/gametest/EntityPredicateTest.java
+++ b/fabric/forgero-fabric-core/src/test/java/com/sigmundgranaas/forgero/fabric/gametest/EntityPredicateTest.java
@@ -12,6 +12,9 @@ import com.sigmundgranaas.forgero.minecraft.common.predicate.entity.EntityPredic
 import com.sigmundgranaas.forgero.minecraft.common.predicate.entity.EntityTypePredicate;
 import com.sigmundgranaas.forgero.testutil.PlayerFactory;
 import com.sigmundgranaas.forgero.testutil.TestPos;
+
+import net.minecraft.util.Hand;
+
 import org.junit.jupiter.api.Assertions;
 
 import net.minecraft.entity.Entity;
@@ -123,6 +126,14 @@ public class EntityPredicateTest {
 		assertTrue(IS_ON_GROUND.value().test(player));
 		player.setOnGround(false);
 		assertFalse(IS_ON_GROUND.value().test(player));
+
+		player.setStackInHand(Hand.MAIN_HAND, new ItemStack(Items.BOW));
+		player.getMainHandStack().use(context.getWorld(), player, Hand.MAIN_HAND);
+		player.tick();
+		assertTrue(IS_USING.value().test(player));
+		player.stopUsingItem();
+		player.tick();
+		assertFalse(IS_USING.value().test(player));
 
 		context.complete();
 	}

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/client/model/baked/strategy/DefaultModelStrategy.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/client/model/baked/strategy/DefaultModelStrategy.java
@@ -39,9 +39,9 @@ public class DefaultModelStrategy implements ModelStrategy {
 	@Override
 	public Optional<BakedModelResult> getModel(State state, MatchContext context) {
 		Optional<ItemStack> stack = context.get(STACK);
-		if (stack.isPresent() && !stack.get().hasNbt()) {
+		if (stack.isPresent() && !stack.get().hasNbt() && result.result().isValid(state, context)) {
 			return Optional.of(result);
-		} else if (code == state.hashCode()) {
+		} else if (code == state.hashCode() && result.result().isValid(state, context)) {
 			return Optional.of(result);
 		} else {
 			return Optional.empty();

--- a/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/predicate/entity/EntityFlagPredicates.java
+++ b/fabric/minecraft-common/src/main/java/com/sigmundgranaas/forgero/minecraft/common/predicate/entity/EntityFlagPredicates.java
@@ -8,10 +8,23 @@ import java.util.function.Predicate;
 import com.sigmundgranaas.forgero.minecraft.common.predicate.codecs.KeyPair;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
 
 public class EntityFlagPredicates {
+	public static final Predicate<Entity> isUsing = new IsUsing();
+
 	public static KeyPair<Predicate<Entity>> IS_SNEAKING = predicate("is_sneaking", Entity::isSneaking);
 	public static KeyPair<Predicate<Entity>> IS_SPRINTING = predicate("is_sprinting", Entity::isSprinting);
 	public static KeyPair<Predicate<Entity>> IS_SWIMMING = predicate("is_swimming", Entity::isSwimming);
 	public static KeyPair<Predicate<Entity>> IS_ON_GROUND = predicate("is_on_ground", Entity::isOnGround);
+	public static KeyPair<Predicate<Entity>> IS_USING = predicate("is_using", isUsing);
+
+
+	private static class IsUsing implements Predicate<Entity> {
+
+		@Override
+		public boolean test(Entity entity) {
+			return entity instanceof PlayerEntity player && player.getItemUseTime() != player.getItemUseTimeLeft();
+		}
+	}
 }


### PR DESCRIPTION
Closes #

Usage example:

Pickaxe head schematic:
```json
features": [
      {
        "type": "minecraft:on_use",
        "max_use_time": 72000,
        "use_action": "SPEAR",
        "use": [
          {
            "type": "minecraft:consume"
          }
        ],
        "on_stop": [
          {
            "type": "forgero:throw"
          },
          {
            "type": "minecraft:play_sound",
            "sound": "minecraft:item.trident.throw"
          }
        ]
      }
    ]
```

Pickaxe head model
```json
 {
      "name": "pickaxe_head",
      "template": "pickaxe_head.png",
      "type": "GENERATE",
      "palette": "TOOL_MATERIAL",
      "order": 20,
      "variants": [
        {
          "target":[
            {
              "type": "minecraft:entity",
              "flag": {
                "is_using": true
              }
            }
          ],
          "display_overrides": {
            "thirdperson_righthand": {
              "rotation": [ 0, 90, -135],
              "translation": [ 0, -4, 2 ],
              "scale": [ 1, 1, 1 ]
            },
            "thirdperson_lefthand": {
              "rotation": [ 0, 90, -135],
              "translation": [ 0, -4, 2 ],
              "scale": [ 1, 1, 1 ]
            },
            "firstperson_righthand": {
              "rotation": [ 0, 90, -135],
              "translation": [ 0, -4, 2 ],
              "scale": [ 1, 1, 1 ]
            },
            "firstperson_lefthand": {
              "rotation": [ 0, 90, -135],
              "translation": [ 0, -4, 2 ],
              "scale": [ 1, 1, 1 ]
            }
          }
        }
      ]
```
Result
![image](https://github.com/user-attachments/assets/73353d5f-86f3-487a-8e1b-8b7805612854)



